### PR TITLE
Add admin CRUD for config, flags, and prompts

### DIFF
--- a/backend/src/middleware/adminAuth.test.ts
+++ b/backend/src/middleware/adminAuth.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Request, Response, NextFunction } from 'express';
+import { ApiErrorCode } from 'shared';
+
+// Mock Supabase first
+vi.mock('../services/supabase.js', () => ({
+  supabase: {
+    auth: {
+      getUser: vi.fn(),
+    },
+  },
+}));
+
+import { requireAdmin } from './adminAuth.js';
+
+describe('Admin Authentication Middleware', () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+  let mockSupabase: any;
+
+  beforeEach(async () => {
+    req = {
+      headers: {
+        authorization: 'Bearer valid-token',
+      },
+      ctx: undefined,
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+    next = vi.fn();
+    vi.clearAllMocks();
+    
+    // Get the mocked supabase
+    const { supabase } = await import('../services/supabase.js');
+    mockSupabase = vi.mocked(supabase);
+  });
+
+  it('should allow admin users to access admin routes', async () => {
+    // Mock admin user
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: {
+        user: {
+          id: 'admin-user-123',
+          email: 'admin@example.com',
+          user_metadata: {
+            role: 'admin',
+          },
+        },
+      },
+      error: null,
+    });
+
+    await requireAdmin(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.ctx).toEqual({
+      userId: 'admin-user-123',
+      isGuest: false,
+      user: {
+        id: 'admin-user-123',
+        email: 'admin@example.com',
+        isGuest: false,
+        role: 'admin',
+      },
+    });
+  });
+
+  it('should reject non-admin users with FORBIDDEN', async () => {
+    // Mock regular user
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: {
+        user: {
+          id: 'regular-user-123',
+          email: 'user@example.com',
+          user_metadata: {
+            role: 'user',
+          },
+        },
+      },
+      error: null,
+    });
+
+    await requireAdmin(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      ok: false,
+      error: {
+        code: ApiErrorCode.FORBIDDEN,
+        message: 'Admin access required',
+      },
+      meta: {
+        traceId: expect.any(String),
+      },
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should reject users without role metadata', async () => {
+    // Mock user without role
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: {
+        user: {
+          id: 'user-123',
+          email: 'user@example.com',
+          user_metadata: {},
+        },
+      },
+      error: null,
+    });
+
+    await requireAdmin(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      ok: false,
+      error: {
+        code: ApiErrorCode.FORBIDDEN,
+        message: 'Admin access required',
+      },
+      meta: {
+        traceId: expect.any(String),
+      },
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should reject invalid tokens with UNAUTHORIZED', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: null },
+      error: new Error('Invalid token'),
+    });
+
+    await requireAdmin(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      ok: false,
+      error: {
+        code: ApiErrorCode.UNAUTHORIZED,
+        message: 'Invalid or expired token',
+      },
+      meta: {
+        traceId: expect.any(String),
+      },
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should reject requests without authorization header', async () => {
+    req.headers = {};
+
+    await requireAdmin(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      ok: false,
+      error: {
+        code: ApiErrorCode.UNAUTHORIZED,
+        message: 'Authentication required',
+      },
+      meta: {
+        traceId: expect.any(String),
+      },
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should handle Supabase errors gracefully', async () => {
+    mockSupabase.auth.getUser.mockRejectedValue(new Error('Supabase error'));
+
+    await requireAdmin(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      ok: false,
+      error: {
+        code: ApiErrorCode.INTERNAL_ERROR,
+        message: 'Authentication failed',
+      },
+      meta: {
+        traceId: expect.any(String),
+      },
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/middleware/adminAuth.ts
+++ b/backend/src/middleware/adminAuth.ts
@@ -1,0 +1,85 @@
+import { Request, Response, NextFunction } from 'express';
+import { supabase } from '../services/supabase.js';
+import { sendErrorWithStatus } from '../utils/response.js';
+import { ApiErrorCode } from 'shared';
+
+// Extend Request type to include admin user context
+declare global {
+  namespace Express {
+    interface Request {
+      ctx?: {
+        userId?: string;
+        isGuest?: boolean;
+        user?: {
+          id: string;
+          email?: string;
+          isGuest: boolean;
+          role?: string;
+        };
+      };
+    }
+  }
+}
+
+// Admin authentication middleware
+export async function requireAdmin(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const authHeader = req.headers.authorization;
+    
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return sendErrorWithStatus(
+        res,
+        ApiErrorCode.UNAUTHORIZED,
+        'Authentication required',
+        req
+      );
+    }
+
+    const token = authHeader.substring(7); // Remove 'Bearer ' prefix
+    
+    // Verify JWT with Supabase
+    const { data: { user }, error } = await supabase.auth.getUser(token);
+    
+    if (error || !user) {
+      return sendErrorWithStatus(
+        res,
+        ApiErrorCode.UNAUTHORIZED,
+        'Invalid or expired token',
+        req
+      );
+    }
+
+    // Check if user has admin role
+    const userRole = user.user_metadata?.role;
+    if (userRole !== 'admin') {
+      return sendErrorWithStatus(
+        res,
+        ApiErrorCode.FORBIDDEN,
+        'Admin access required',
+        req
+      );
+    }
+
+    // Set admin user context
+    req.ctx = {
+      userId: user.id,
+      isGuest: false,
+      user: {
+        id: user.id,
+        email: user.email,
+        isGuest: false,
+        role: userRole,
+      },
+    };
+
+    next();
+  } catch (error) {
+    console.error('Admin auth middleware error:', error);
+    return sendErrorWithStatus(
+      res,
+      ApiErrorCode.INTERNAL_ERROR,
+      'Authentication failed',
+      req
+    );
+  }
+}

--- a/backend/src/services/adminConfig.service.test.ts
+++ b/backend/src/services/adminConfig.service.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AdminConfigService } from './adminConfig.service.js';
+import { ApiErrorCode } from 'shared';
+
+// Mock Supabase admin client
+const mockSupabaseAdmin = {
+  from: vi.fn(() => ({
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        single: vi.fn(),
+        maybeSingle: vi.fn(),
+      })),
+      order: vi.fn(() => ({
+        limit: vi.fn(),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn(),
+      })),
+    })),
+    update: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn(),
+        })),
+      })),
+    })),
+    upsert: vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn(),
+      })),
+    })),
+  })),
+};
+
+vi.mock('./supabase.js', () => ({
+  supabaseAdmin: mockSupabaseAdmin,
+}));
+
+describe('AdminConfigService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getAllConfig', () => {
+    it('should return all configuration tables', async () => {
+      const mockConfigData = {
+        app: [
+          { key: 'cookie_ttl_days', value: { value: 60 }, type: 'number', updated_at: '2023-01-01T00:00:00Z' },
+        ],
+        pricing: [
+          { key: 'turn_cost_default', value: { value: 2 }, updated_at: '2023-01-01T00:00:00Z' },
+        ],
+        ai: [
+          { key: 'active_model', value: { value: 'gpt-4' }, updated_at: '2023-01-01T00:00:00Z' },
+        ],
+      };
+
+      // Mock the database responses
+      mockSupabaseAdmin.from.mockImplementation((table: string) => {
+        const mockQuery = {
+          select: vi.fn(() => ({
+            order: vi.fn(() => ({
+              limit: vi.fn().mockResolvedValue({
+                data: mockConfigData[table as keyof typeof mockConfigData] || [],
+                error: null,
+              }),
+            })),
+          })),
+        };
+        return mockQuery;
+      });
+
+      const result = await AdminConfigService.getAllConfig();
+
+      expect(result).toEqual({
+        app: [
+          { key: 'cookie_ttl_days', value: { value: 60 }, type: 'number', updated_at: '2023-01-01T00:00:00Z' },
+        ],
+        pricing: [
+          { key: 'turn_cost_default', value: { value: 2 }, updated_at: '2023-01-01T00:00:00Z' },
+        ],
+        ai: [
+          { key: 'active_model', value: { value: 'gpt-4' }, updated_at: '2023-01-01T00:00:00Z' },
+        ],
+      });
+    });
+
+    it('should handle database errors', async () => {
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        select: vi.fn(() => ({
+          order: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue({
+              data: null,
+              error: new Error('Database error'),
+            }),
+          })),
+        })),
+      }));
+
+      await expect(AdminConfigService.getAllConfig()).rejects.toThrow('Database error');
+    });
+  });
+
+  describe('updateConfigValue', () => {
+    it('should update app config value and increment version', async () => {
+      const mockUpdatedConfig = {
+        key: 'cookie_ttl_days',
+        value: { value: 90 },
+        type: 'number',
+        updated_at: '2023-01-01T00:00:00Z',
+      };
+
+      mockSupabaseAdmin.from.mockImplementation((table: string) => {
+        if (table === 'app_config') {
+          return {
+            update: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                select: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({
+                    data: mockUpdatedConfig,
+                    error: null,
+                  }),
+                })),
+              })),
+            })),
+          };
+        } else if (table === 'config_meta') {
+          return {
+            update: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                select: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({
+                    data: { version: 2 },
+                    error: null,
+                  }),
+                })),
+              })),
+            })),
+          };
+        }
+        return {};
+      });
+
+      const result = await AdminConfigService.updateConfigValue('app', 'cookie_ttl_days', { value: 90 });
+
+      expect(result).toEqual(mockUpdatedConfig);
+    });
+
+    it('should update pricing config value', async () => {
+      const mockUpdatedConfig = {
+        key: 'turn_cost_default',
+        value: { value: 3 },
+        updated_at: '2023-01-01T00:00:00Z',
+      };
+
+      mockSupabaseAdmin.from.mockImplementation((table: string) => {
+        if (table === 'pricing_config') {
+          return {
+            update: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                select: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({
+                    data: mockUpdatedConfig,
+                    error: null,
+                  }),
+                })),
+              })),
+            })),
+          };
+        } else if (table === 'config_meta') {
+          return {
+            update: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                select: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({
+                    data: { version: 2 },
+                    error: null,
+                  }),
+                })),
+              })),
+            })),
+          };
+        }
+        return {};
+      });
+
+      const result = await AdminConfigService.updateConfigValue('pricing', 'turn_cost_default', { value: 3 });
+
+      expect(result).toEqual(mockUpdatedConfig);
+    });
+
+    it('should throw CONFIG_NOT_FOUND for non-existent config key', async () => {
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: null,
+                error: null,
+              }),
+            })),
+          })),
+        })),
+      }));
+
+      await expect(
+        AdminConfigService.updateConfigValue('app', 'non_existent_key', { value: 'test' })
+      ).rejects.toThrow('Config key not found: non_existent_key');
+    });
+
+    it('should handle database errors during update', async () => {
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: null,
+                error: new Error('Database error'),
+              }),
+            })),
+          })),
+        })),
+      }));
+
+      await expect(
+        AdminConfigService.updateConfigValue('app', 'cookie_ttl_days', { value: 90 })
+      ).rejects.toThrow('Database error');
+    });
+  });
+
+  describe('validateConfigType', () => {
+    it('should validate app config types correctly', () => {
+      expect(() => AdminConfigService.validateConfigType('app', 'cookie_ttl_days', { value: 60 })).not.toThrow();
+      expect(() => AdminConfigService.validateConfigType('app', 'idempotency_required', { value: true })).not.toThrow();
+      expect(() => AdminConfigService.validateConfigType('app', 'drifter_enabled', { value: 'true' })).toThrow('Invalid type for app config key');
+    });
+
+    it('should allow any value for pricing and ai config', () => {
+      expect(() => AdminConfigService.validateConfigType('pricing', 'turn_cost_default', { value: 2 })).not.toThrow();
+      expect(() => AdminConfigService.validateConfigType('pricing', 'turn_cost_default', { value: 'invalid' })).not.toThrow();
+      expect(() => AdminConfigService.validateConfigType('ai', 'active_model', { value: 'gpt-4' })).not.toThrow();
+    });
+  });
+});

--- a/backend/src/services/adminConfig.service.ts
+++ b/backend/src/services/adminConfig.service.ts
@@ -1,0 +1,143 @@
+import { supabaseAdmin } from './supabase.js';
+import { ApiErrorCode } from 'shared';
+
+export interface ConfigRow {
+  key: string;
+  value: any;
+  type?: string;
+  updated_at: string;
+}
+
+export interface ConfigMetaRow {
+  version: number;
+  updated_at: string;
+}
+
+export class AdminConfigService {
+  /**
+   * Get all configuration tables (full, not redacted)
+   */
+  static async getAllConfig(): Promise<{
+    app: ConfigRow[];
+    pricing: ConfigRow[];
+    ai: ConfigRow[];
+  }> {
+    try {
+      const [appRes, pricingRes, aiRes] = await Promise.all([
+        supabaseAdmin.from('app_config').select('*').order('key'),
+        supabaseAdmin.from('pricing_config').select('*').order('key'),
+        supabaseAdmin.from('ai_config').select('*').order('key'),
+      ]);
+
+      if (appRes.error) throw appRes.error;
+      if (pricingRes.error) throw pricingRes.error;
+      if (aiRes.error) throw aiRes.error;
+
+      return {
+        app: appRes.data || [],
+        pricing: pricingRes.data || [],
+        ai: aiRes.data || [],
+      };
+    } catch (error) {
+      console.error('Error fetching all config:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Update a single config value and increment version
+   */
+  static async updateConfigValue(
+    table: 'app' | 'pricing' | 'ai',
+    key: string,
+    value: any
+  ): Promise<ConfigRow> {
+    try {
+      // Validate config type for app config
+      if (table === 'app') {
+        this.validateConfigType(table, key, value);
+      }
+
+      const tableName = `${table}_config`;
+      
+      // Update the config value
+      const { data, error } = await supabaseAdmin
+        .from(tableName)
+        .update({ value })
+        .eq('key', key)
+        .select()
+        .single();
+
+      if (error) throw error;
+      if (!data) {
+        throw new Error(`Config key not found: ${key}`);
+      }
+
+      // Increment config version
+      await this.incrementConfigVersion();
+
+      return data;
+    } catch (error) {
+      console.error(`Error updating ${table} config:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Validate config type for app config
+   */
+  static validateConfigType(table: 'app' | 'pricing' | 'ai', key: string, value: any): void {
+    if (table !== 'app') return; // Only validate app config types
+
+    const expectedTypes: Record<string, string> = {
+      cookie_ttl_days: 'number',
+      idempotency_required: 'boolean',
+      allow_async_turn_fallback: 'boolean',
+      telemetry_sample_rate: 'number',
+      drifter_enabled: 'boolean',
+    };
+
+    const expectedType = expectedTypes[key];
+    if (!expectedType) return; // Unknown key, skip validation
+
+    const actualType = typeof value.value;
+    if (actualType !== expectedType) {
+      throw new Error(`Invalid type for app config key ${key}: expected ${expectedType}, got ${actualType}`);
+    }
+  }
+
+  /**
+   * Increment config version in config_meta table
+   */
+  private static async incrementConfigVersion(): Promise<void> {
+    try {
+      const { error } = await supabaseAdmin
+        .from('config_meta')
+        .update({ version: supabaseAdmin.raw('version + 1') })
+        .eq('id', true);
+
+      if (error) throw error;
+    } catch (error) {
+      console.error('Error incrementing config version:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get config version
+   */
+  static async getConfigVersion(): Promise<number> {
+    try {
+      const { data, error } = await supabaseAdmin
+        .from('config_meta')
+        .select('version')
+        .single();
+
+      if (error) throw error;
+      return data?.version || 1;
+    } catch (error) {
+      console.error('Error getting config version:', error);
+      throw error;
+    }
+  }
+}

--- a/backend/src/services/featureFlags.service.test.ts
+++ b/backend/src/services/featureFlags.service.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FeatureFlagsService } from './featureFlags.service.js';
+import { ApiErrorCode } from 'shared';
+
+// Mock Supabase admin client
+const mockSupabaseAdmin = {
+  from: vi.fn(() => ({
+    select: vi.fn(() => ({
+      order: vi.fn(() => ({
+        limit: vi.fn(),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn(),
+      })),
+    })),
+    update: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn(),
+        })),
+      })),
+    })),
+    upsert: vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn(),
+      })),
+    })),
+  })),
+};
+
+vi.mock('./supabase.js', () => ({
+  supabaseAdmin: mockSupabaseAdmin,
+}));
+
+describe('FeatureFlagsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getAllFlags', () => {
+    it('should return all feature flags', async () => {
+      const mockFlags = [
+        { key: 'stones_show_guest_pill', enabled: true, payload: {}, updated_at: '2023-01-01T00:00:00Z' },
+        { key: 'drifter_onboarding', enabled: false, payload: { step: 1 }, updated_at: '2023-01-01T00:00:00Z' },
+      ];
+
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        select: vi.fn(() => ({
+          order: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue({
+              data: mockFlags,
+              error: null,
+            }),
+          })),
+        })),
+      }));
+
+      const result = await FeatureFlagsService.getAllFlags();
+
+      expect(result).toEqual(mockFlags);
+    });
+
+    it('should handle database errors', async () => {
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        select: vi.fn(() => ({
+          order: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue({
+              data: null,
+              error: new Error('Database error'),
+            }),
+          })),
+        })),
+      }));
+
+      await expect(FeatureFlagsService.getAllFlags()).rejects.toThrow('Database error');
+    });
+  });
+
+  describe('updateFlag', () => {
+    it('should update flag enabled status', async () => {
+      const mockUpdatedFlag = {
+        key: 'stones_show_guest_pill',
+        enabled: false,
+        payload: {},
+        updated_at: '2023-01-01T00:00:00Z',
+      };
+
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: mockUpdatedFlag,
+                error: null,
+              }),
+            })),
+          })),
+        })),
+      }));
+
+      const result = await FeatureFlagsService.updateFlag('stones_show_guest_pill', { enabled: false });
+
+      expect(result).toEqual(mockUpdatedFlag);
+    });
+
+    it('should update flag payload', async () => {
+      const mockUpdatedFlag = {
+        key: 'drifter_onboarding',
+        enabled: true,
+        payload: { step: 2, completed: true },
+        updated_at: '2023-01-01T00:00:00Z',
+      };
+
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: mockUpdatedFlag,
+                error: null,
+              }),
+            })),
+          })),
+        })),
+      }));
+
+      const result = await FeatureFlagsService.updateFlag('drifter_onboarding', { 
+        payload: { step: 2, completed: true } 
+      });
+
+      expect(result).toEqual(mockUpdatedFlag);
+    });
+
+    it('should update both enabled and payload', async () => {
+      const mockUpdatedFlag = {
+        key: 'ws_push_enabled',
+        enabled: true,
+        payload: { endpoint: 'wss://example.com' },
+        updated_at: '2023-01-01T00:00:00Z',
+      };
+
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: mockUpdatedFlag,
+                error: null,
+              }),
+            })),
+          })),
+        })),
+      }));
+
+      const result = await FeatureFlagsService.updateFlag('ws_push_enabled', { 
+        enabled: true,
+        payload: { endpoint: 'wss://example.com' }
+      });
+
+      expect(result).toEqual(mockUpdatedFlag);
+    });
+
+    it('should throw FLAG_NOT_FOUND for non-existent flag', async () => {
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: null,
+                error: null,
+              }),
+            })),
+          })),
+        })),
+      }));
+
+      await expect(
+        FeatureFlagsService.updateFlag('non_existent_flag', { enabled: true })
+      ).rejects.toThrow('Feature flag not found: non_existent_flag');
+    });
+
+    it('should handle database errors during update', async () => {
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: null,
+                error: new Error('Database error'),
+              }),
+            })),
+          })),
+        })),
+      }));
+
+      await expect(
+        FeatureFlagsService.updateFlag('stones_show_guest_pill', { enabled: false })
+      ).rejects.toThrow('Database error');
+    });
+  });
+
+  describe('createFlag', () => {
+    it('should create a new feature flag', async () => {
+      const mockNewFlag = {
+        key: 'new_feature',
+        enabled: false,
+        payload: {},
+        updated_at: '2023-01-01T00:00:00Z',
+      };
+
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        insert: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn().mockResolvedValue({
+              data: mockNewFlag,
+              error: null,
+            }),
+          })),
+        })),
+      }));
+
+      const result = await FeatureFlagsService.createFlag('new_feature', false, {});
+
+      expect(result).toEqual(mockNewFlag);
+    });
+
+    it('should handle database errors during creation', async () => {
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        insert: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: new Error('Database error'),
+            }),
+          })),
+        })),
+      }));
+
+      await expect(
+        FeatureFlagsService.createFlag('new_feature', false, {})
+      ).rejects.toThrow('Database error');
+    });
+  });
+});

--- a/backend/src/services/featureFlags.service.ts
+++ b/backend/src/services/featureFlags.service.ts
@@ -1,0 +1,129 @@
+import { supabaseAdmin } from './supabase.js';
+
+export interface FeatureFlag {
+  key: string;
+  enabled: boolean;
+  payload: Record<string, unknown>;
+  updated_at: string;
+}
+
+export class FeatureFlagsService {
+  /**
+   * Get all feature flags
+   */
+  static async getAllFlags(): Promise<FeatureFlag[]> {
+    try {
+      const { data, error } = await supabaseAdmin
+        .from('feature_flags')
+        .select('*')
+        .order('key');
+
+      if (error) throw error;
+      return data || [];
+    } catch (error) {
+      console.error('Error fetching feature flags:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Update a feature flag
+   */
+  static async updateFlag(
+    key: string,
+    updates: {
+      enabled?: boolean;
+      payload?: Record<string, unknown>;
+    }
+  ): Promise<FeatureFlag> {
+    try {
+      const updateData: Partial<FeatureFlag> = {};
+      if (updates.enabled !== undefined) updateData.enabled = updates.enabled;
+      if (updates.payload !== undefined) updateData.payload = updates.payload;
+
+      const { data, error } = await supabaseAdmin
+        .from('feature_flags')
+        .update(updateData)
+        .eq('key', key)
+        .select()
+        .single();
+
+      if (error) throw error;
+      if (!data) {
+        throw new Error(`Feature flag not found: ${key}`);
+      }
+
+      return data;
+    } catch (error) {
+      console.error(`Error updating feature flag ${key}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Create a new feature flag
+   */
+  static async createFlag(
+    key: string,
+    enabled: boolean = false,
+    payload: Record<string, unknown> = {}
+  ): Promise<FeatureFlag> {
+    try {
+      const { data, error } = await supabaseAdmin
+        .from('feature_flags')
+        .insert({
+          key,
+          enabled,
+          payload,
+        })
+        .select()
+        .single();
+
+      if (error) throw error;
+      return data;
+    } catch (error) {
+      console.error(`Error creating feature flag ${key}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get a specific feature flag
+   */
+  static async getFlag(key: string): Promise<FeatureFlag | null> {
+    try {
+      const { data, error } = await supabaseAdmin
+        .from('feature_flags')
+        .select('*')
+        .eq('key', key)
+        .single();
+
+      if (error) {
+        if (error.code === 'PGRST116') return null; // No rows returned
+        throw error;
+      }
+
+      return data;
+    } catch (error) {
+      console.error(`Error fetching feature flag ${key}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Delete a feature flag
+   */
+  static async deleteFlag(key: string): Promise<void> {
+    try {
+      const { error } = await supabaseAdmin
+        .from('feature_flags')
+        .delete()
+        .eq('key', key);
+
+      if (error) throw error;
+    } catch (error) {
+      console.error(`Error deleting feature flag ${key}:`, error);
+      throw error;
+    }
+  }
+}

--- a/backend/src/services/prompts.service.test.ts
+++ b/backend/src/services/prompts.service.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PromptsService } from './prompts.service.js';
+import { ApiErrorCode } from 'shared';
+
+// Mock Supabase admin client
+const mockSupabaseAdmin = {
+  from: vi.fn(() => ({
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        single: vi.fn(),
+        order: vi.fn(() => ({
+          limit: vi.fn(),
+        })),
+      })),
+      order: vi.fn(() => ({
+        limit: vi.fn(),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn(),
+      })),
+    })),
+    update: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn(),
+        })),
+      })),
+    })),
+    delete: vi.fn(() => ({
+      eq: vi.fn(),
+    })),
+  })),
+};
+
+vi.mock('./supabase.js', () => ({
+  supabaseAdmin: mockSupabaseAdmin,
+}));
+
+describe('PromptsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getAllPrompts', () => {
+    it('should return all prompts with filters', async () => {
+      const mockPrompts = [
+        {
+          id: 'prompt-1',
+          slug: 'world-intro',
+          scope: 'world',
+          version: 1,
+          hash: 'abc123',
+          content: 'Welcome to the world...',
+          active: true,
+          metadata: {},
+          created_by: 'admin-123',
+          created_at: '2023-01-01T00:00:00Z',
+          updated_at: '2023-01-01T00:00:00Z',
+        },
+        {
+          id: 'prompt-2',
+          slug: 'scenario-start',
+          scope: 'scenario',
+          version: 1,
+          hash: 'def456',
+          content: 'The scenario begins...',
+          active: false,
+          metadata: {},
+          created_by: 'admin-123',
+          created_at: '2023-01-01T00:00:00Z',
+          updated_at: '2023-01-01T00:00:00Z',
+        },
+      ];
+
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        select: vi.fn(() => ({
+          order: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue({
+              data: mockPrompts,
+              error: null,
+            }),
+          })),
+        })),
+      }));
+
+      const result = await PromptsService.getAllPrompts();
+
+      expect(result).toEqual(mockPrompts);
+    });
+
+    it('should filter prompts by scope', async () => {
+      const mockPrompts = [
+        {
+          id: 'prompt-1',
+          slug: 'world-intro',
+          scope: 'world',
+          version: 1,
+          hash: 'abc123',
+          content: 'Welcome to the world...',
+          active: true,
+          metadata: {},
+          created_by: 'admin-123',
+          created_at: '2023-01-01T00:00:00Z',
+          updated_at: '2023-01-01T00:00:00Z',
+        },
+      ];
+
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            order: vi.fn(() => ({
+              limit: vi.fn().mockResolvedValue({
+                data: mockPrompts,
+                error: null,
+              }),
+            })),
+          })),
+        })),
+      }));
+
+      const result = await PromptsService.getAllPrompts({ scope: 'world' });
+
+      expect(result).toEqual(mockPrompts);
+    });
+
+    it('should handle database errors', async () => {
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        select: vi.fn(() => ({
+          order: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue({
+              data: null,
+              error: new Error('Database error'),
+            }),
+          })),
+        })),
+      }));
+
+      await expect(PromptsService.getAllPrompts()).rejects.toThrow('Database error');
+    });
+  });
+
+  describe('createPrompt', () => {
+    it('should create a new prompt version and deactivate previous versions', async () => {
+      const mockNewPrompt = {
+        id: 'prompt-2',
+        slug: 'world-intro',
+        scope: 'world',
+        version: 2,
+        hash: 'newhash123',
+        content: 'Updated world intro...',
+        active: true,
+        metadata: { author: 'admin' },
+        created_by: 'admin-123',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+      };
+
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        insert: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn().mockResolvedValue({
+              data: mockNewPrompt,
+              error: null,
+            }),
+          })),
+        })),
+      }));
+
+      const result = await PromptsService.createPrompt({
+        slug: 'world-intro',
+        scope: 'world',
+        content: 'Updated world intro...',
+        metadata: { author: 'admin' },
+        active: true,
+      });
+
+      expect(result).toEqual(mockNewPrompt);
+    });
+
+    it('should handle database errors during creation', async () => {
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        insert: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: new Error('Database error'),
+            }),
+          })),
+        })),
+      }));
+
+      await expect(
+        PromptsService.createPrompt({
+          slug: 'world-intro',
+          scope: 'world',
+          content: 'New content...',
+        })
+      ).rejects.toThrow('Database error');
+    });
+  });
+
+  describe('updatePrompt', () => {
+    it('should update prompt metadata and active status', async () => {
+      const mockUpdatedPrompt = {
+        id: 'prompt-1',
+        slug: 'world-intro',
+        scope: 'world',
+        version: 1,
+        hash: 'abc123',
+        content: 'Welcome to the world...',
+        active: false,
+        metadata: { updated: true },
+        created_by: 'admin-123',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+      };
+
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: mockUpdatedPrompt,
+                error: null,
+              }),
+            })),
+          })),
+        })),
+      }));
+
+      const result = await PromptsService.updatePrompt('prompt-1', {
+        active: false,
+        metadata: { updated: true },
+      });
+
+      expect(result).toEqual(mockUpdatedPrompt);
+    });
+
+    it('should throw PROMPT_NOT_FOUND for non-existent prompt', async () => {
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: null,
+                error: null,
+              }),
+            })),
+          })),
+        })),
+      }));
+
+      await expect(
+        PromptsService.updatePrompt('non-existent-id', { active: false })
+      ).rejects.toThrow('Prompt not found: non-existent-id');
+    });
+
+    it('should handle database errors during update', async () => {
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: null,
+                error: new Error('Database error'),
+              }),
+            })),
+          })),
+        })),
+      }));
+
+      await expect(
+        PromptsService.updatePrompt('prompt-1', { active: false })
+      ).rejects.toThrow('Database error');
+    });
+  });
+
+  describe('deletePrompt', () => {
+    it('should soft delete a prompt by setting active to false', async () => {
+      const mockDeletedPrompt = {
+        id: 'prompt-1',
+        slug: 'world-intro',
+        scope: 'world',
+        version: 1,
+        hash: 'abc123',
+        content: 'Welcome to the world...',
+        active: false,
+        metadata: {},
+        created_by: 'admin-123',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+      };
+
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: mockDeletedPrompt,
+                error: null,
+              }),
+            })),
+          })),
+        })),
+      }));
+
+      const result = await PromptsService.deletePrompt('prompt-1');
+
+      expect(result).toEqual(mockDeletedPrompt);
+    });
+
+    it('should throw PROMPT_NOT_FOUND for non-existent prompt', async () => {
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: null,
+                error: null,
+              }),
+            })),
+          })),
+        })),
+      }));
+
+      await expect(
+        PromptsService.deletePrompt('non-existent-id')
+      ).rejects.toThrow('Prompt not found: non-existent-id');
+    });
+  });
+
+  describe('getActivePrompt', () => {
+    it('should return the active prompt for a given slug and scope', async () => {
+      const mockActivePrompt = {
+        id: 'prompt-1',
+        slug: 'world-intro',
+        scope: 'world',
+        version: 1,
+        hash: 'abc123',
+        content: 'Welcome to the world...',
+        active: true,
+        metadata: {},
+        created_by: 'admin-123',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+      };
+
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: mockActivePrompt,
+                  error: null,
+                }),
+              })),
+            })),
+          })),
+        })),
+      }));
+
+      const result = await PromptsService.getActivePrompt('world-intro', 'world');
+
+      expect(result).toEqual(mockActivePrompt);
+    });
+
+    it('should return null if no active prompt found', async () => {
+      mockSupabaseAdmin.from.mockImplementation(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: null,
+                  error: { code: 'PGRST116' }, // No rows returned
+                }),
+              })),
+            })),
+          })),
+        })),
+      }));
+
+      const result = await PromptsService.getActivePrompt('non-existent', 'world');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/backend/src/utils/response.ts
+++ b/backend/src/utils/response.ts
@@ -89,6 +89,10 @@ export const ERROR_STATUS_MAP: Record<ApiErrorCode, number> = {
   [ApiErrorCode.INVALID_PACK]: 400,
   [ApiErrorCode.PAYMENT_FAILED]: 400,
   [ApiErrorCode.COOKIE_CAP]: 429,
+  [ApiErrorCode.CONFIG_NOT_FOUND]: 404,
+  [ApiErrorCode.FLAG_NOT_FOUND]: 404,
+  [ApiErrorCode.PROMPT_NOT_FOUND]: 404,
+  [ApiErrorCode.PROMPT_VERSION_CONFLICT]: 409,
   [ApiErrorCode.INTERNAL_ERROR]: 500,
 };
 

--- a/shared/src/types/api.ts
+++ b/shared/src/types/api.ts
@@ -14,6 +14,10 @@ export enum ApiErrorCode {
   INVALID_PACK = 'INVALID_PACK',
   PAYMENT_FAILED = 'PAYMENT_FAILED',
   COOKIE_CAP = 'COOKIE_CAP',
+  CONFIG_NOT_FOUND = 'CONFIG_NOT_FOUND',
+  FLAG_NOT_FOUND = 'FLAG_NOT_FOUND',
+  PROMPT_NOT_FOUND = 'PROMPT_NOT_FOUND',
+  PROMPT_VERSION_CONFLICT = 'PROMPT_VERSION_CONFLICT',
   INTERNAL_ERROR = 'INTERNAL_ERROR',
 }
 
@@ -141,6 +145,36 @@ export const TurnResultSchema = z.object({
   option_id: z.string().uuid(),
   ai_response: TurnResponseSchema,
   created_at: z.string().datetime(),
+});
+
+// Admin request schemas
+export const UpdateConfigRequestSchema = z.object({
+  value: z.unknown(),
+});
+
+export const UpdateFlagRequestSchema = z.object({
+  enabled: z.boolean().optional(),
+  payload: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const CreatePromptRequestSchema = z.object({
+  slug: z.string().min(1).max(100),
+  scope: z.enum(['world', 'scenario', 'adventure', 'quest']),
+  content: z.string().min(1),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  active: z.boolean().optional().default(false),
+});
+
+export const UpdatePromptRequestSchema = z.object({
+  content: z.string().min(1).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  active: z.boolean().optional(),
+});
+
+export const PromptFiltersSchema = z.object({
+  scope: z.enum(['world', 'scenario', 'adventure', 'quest']).optional(),
+  slug: z.string().optional(),
+  active: z.boolean().optional(),
 });
 
 // Type exports

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -227,3 +227,20 @@ export const PaymentSessionSchema = z.object({
 });
 
 export type PaymentSession = z.infer<typeof PaymentSessionSchema>;
+
+// Prompt Schema
+export const PromptSchema = z.object({
+  id: z.string().uuid(),
+  slug: z.string().min(1).max(100),
+  scope: z.enum(['world', 'scenario', 'adventure', 'quest']),
+  version: z.number().int().min(1),
+  hash: z.string().length(64), // SHA-256 hash
+  content: z.string().min(1),
+  active: z.boolean(),
+  metadata: z.record(z.string(), z.unknown()),
+  createdBy: z.string().uuid().optional(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export type Prompt = z.infer<typeof PromptSchema>;

--- a/supabase/migrations/005_prompts_table.sql
+++ b/supabase/migrations/005_prompts_table.sql
@@ -1,0 +1,132 @@
+-- Prompts table for versioned prompt management
+-- Each prompt has id, slug, scope (world/scenario/adventure/quest), version, hash, content, active
+
+CREATE TABLE IF NOT EXISTS prompts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug TEXT NOT NULL,
+  scope TEXT NOT NULL CHECK (scope IN ('world', 'scenario', 'adventure', 'quest')),
+  version INTEGER NOT NULL DEFAULT 1,
+  hash TEXT NOT NULL, -- SHA-256 hash of content for integrity
+  content TEXT NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT FALSE,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  
+  -- Ensure only one active version per slug/scope combination
+  UNIQUE (slug, scope, active) DEFERRABLE INITIALLY DEFERRED,
+  -- Ensure unique version per slug/scope
+  UNIQUE (slug, scope, version)
+);
+
+-- Create indexes for efficient querying
+CREATE INDEX IF NOT EXISTS idx_prompts_slug_scope ON prompts(slug, scope);
+CREATE INDEX IF NOT EXISTS idx_prompts_active ON prompts(active) WHERE active = TRUE;
+CREATE INDEX IF NOT EXISTS idx_prompts_created_at ON prompts(created_at);
+
+-- Ensure updated_at trigger exists
+DROP TRIGGER IF EXISTS update_prompts_updated_at ON prompts;
+CREATE TRIGGER update_prompts_updated_at
+  BEFORE UPDATE ON prompts
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- Function to ensure only one active version per slug/scope
+CREATE OR REPLACE FUNCTION ensure_single_active_prompt()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- If setting a prompt to active, deactivate all other versions of the same slug/scope
+  IF NEW.active = TRUE THEN
+    UPDATE prompts 
+    SET active = FALSE 
+    WHERE slug = NEW.slug 
+      AND scope = NEW.scope 
+      AND id != NEW.id;
+  END IF;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to enforce single active version
+DROP TRIGGER IF EXISTS trigger_ensure_single_active_prompt ON prompts;
+CREATE TRIGGER trigger_ensure_single_active_prompt
+  BEFORE INSERT OR UPDATE ON prompts
+  FOR EACH ROW
+  EXECUTE FUNCTION ensure_single_active_prompt();
+
+-- Function to generate content hash
+CREATE OR REPLACE FUNCTION generate_content_hash(content TEXT)
+RETURNS TEXT AS $$
+BEGIN
+  RETURN encode(digest(content, 'sha256'), 'hex');
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to auto-generate hash on insert/update
+CREATE OR REPLACE FUNCTION auto_generate_prompt_hash()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.hash = generate_content_hash(NEW.content);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to auto-generate hash
+DROP TRIGGER IF EXISTS trigger_auto_generate_prompt_hash ON prompts;
+CREATE TRIGGER trigger_auto_generate_prompt_hash
+  BEFORE INSERT OR UPDATE ON prompts
+  FOR EACH ROW
+  EXECUTE FUNCTION auto_generate_prompt_hash();
+
+-- Function to auto-increment version for new prompts
+CREATE OR REPLACE FUNCTION auto_increment_prompt_version()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Only auto-increment on INSERT, not UPDATE
+  IF TG_OP = 'INSERT' THEN
+    -- Get the next version number for this slug/scope
+    SELECT COALESCE(MAX(version), 0) + 1 
+    INTO NEW.version
+    FROM prompts 
+    WHERE slug = NEW.slug AND scope = NEW.scope;
+  END IF;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to auto-increment version
+DROP TRIGGER IF EXISTS trigger_auto_increment_prompt_version ON prompts;
+CREATE TRIGGER trigger_auto_increment_prompt_version
+  BEFORE INSERT ON prompts
+  FOR EACH ROW
+  EXECUTE FUNCTION auto_increment_prompt_version();
+
+-- RLS policies for prompts table
+ALTER TABLE prompts ENABLE ROW LEVEL SECURITY;
+
+-- Admin users can do everything
+CREATE POLICY "Admin users can manage prompts" ON prompts
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM auth.users 
+      WHERE auth.users.id = auth.uid() 
+      AND auth.users.raw_user_meta_data->>'role' = 'admin'
+    )
+  );
+
+-- Regular users can only read active prompts (for public consumption)
+CREATE POLICY "Users can read active prompts" ON prompts
+  FOR SELECT
+  TO authenticated
+  USING (active = TRUE);
+
+-- Service role can do everything (for server-side operations)
+CREATE POLICY "Service role can manage prompts" ON prompts
+  FOR ALL
+  TO service_role
+  USING (TRUE);


### PR DESCRIPTION
Introduces admin services and middleware for managing configuration, feature flags, and versioned prompts. Adds new test suites, updates API error codes, schemas, and types, and creates the prompts table with triggers and RLS policies for versioned prompt management.