### PR TITLE
Add M1 character and wallet service layers with tests

### DIFF
--- a/backend/src/routes/characters.m1.test.ts
+++ b/backend/src/routes/characters.m1.test.ts
@@ -1,0 +1,601 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import charactersRouter from './characters.js';
+import { supabase } from '../services/supabase.js';
+import { ApiErrorCode } from 'shared';
+
+// Mock the supabase service
+vi.mock('../services/supabase.js', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn(() => ({
+            single: vi.fn(),
+            then: vi.fn()
+          }))
+        }))
+      })),
+      insert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn()
+        }))
+      })),
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn()
+          }))
+        }))
+      })),
+      delete: vi.fn(() => ({
+        eq: vi.fn()
+      }))
+    }))
+  }
+}));
+
+// Mock the content service for world validation
+vi.mock('../services/content.service.js', () => ({
+  contentService: {
+    getWorlds: vi.fn(() => Promise.resolve([
+      { slug: 'mystika', name: 'Mystika' },
+      { slug: 'aetherium', name: 'Aetherium' },
+      { slug: 'voidreach', name: 'Voidreach' }
+    ]))
+  }
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/characters', charactersRouter);
+
+describe('Layer M1 - Character CRUD Operations', () => {
+  const mockUserId = uuidv4();
+  const mockGuestId = uuidv4();
+  const mockCharacterId = uuidv4();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Character Creation (POST /api/characters)', () => {
+    it('should create character for authenticated user with valid worldSlug', async () => {
+      const characterData = {
+        name: 'Test Character',
+        race: 'Human',
+        class: 'Warrior',
+        level: 1,
+        experience: 0,
+        attributes: {
+          strength: 15,
+          dexterity: 12,
+          constitution: 14,
+          intelligence: 10,
+          wisdom: 13,
+          charisma: 11
+        },
+        skills: ['Swordsmanship'],
+        inventory: [],
+        currentHealth: 10,
+        maxHealth: 10,
+        worldSlug: 'mystika'
+      };
+
+      const mockCharacter = {
+        id: mockCharacterId,
+        userId: mockUserId,
+        ...characterData,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+
+      // Mock successful character creation
+      const mockSupabase = vi.mocked(supabase);
+      mockSupabase.from.mockReturnValue({
+        insert: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() => Promise.resolve({ data: mockCharacter, error: null }))
+          }))
+        }))
+      } as any);
+
+      const response = await request(app)
+        .post('/api/characters')
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .send(characterData)
+        .expect(201);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data.id).toBe(mockCharacterId);
+      expect(response.body.data.name).toBe('Test Character');
+      expect(response.body.data.worldSlug).toBe('mystika');
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+
+    it('should create character for guest user with valid worldSlug', async () => {
+      const characterData = {
+        name: 'Guest Character',
+        race: 'Elf',
+        class: 'Mage',
+        level: 1,
+        experience: 0,
+        attributes: {
+          strength: 10,
+          dexterity: 14,
+          constitution: 12,
+          intelligence: 16,
+          wisdom: 15,
+          charisma: 13
+        },
+        skills: ['Magic'],
+        inventory: [],
+        currentHealth: 8,
+        maxHealth: 8,
+        worldSlug: 'aetherium'
+      };
+
+      const mockCharacter = {
+        id: mockCharacterId,
+        userId: mockGuestId,
+        ...characterData,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+
+      // Mock successful character creation for guest
+      const mockSupabase = vi.mocked(supabase);
+      mockSupabase.from.mockReturnValue({
+        insert: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() => Promise.resolve({ data: mockCharacter, error: null }))
+          }))
+        }))
+      } as any);
+
+      const response = await request(app)
+        .post('/api/characters')
+        .set('Cookie', `guestId=${mockGuestId}`)
+        .send(characterData)
+        .expect(201);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data.id).toBe(mockCharacterId);
+      expect(response.body.data.name).toBe('Guest Character');
+      expect(response.body.data.worldSlug).toBe('aetherium');
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+
+    it('should reject character creation with invalid worldSlug', async () => {
+      const characterData = {
+        name: 'Test Character',
+        race: 'Human',
+        class: 'Warrior',
+        level: 1,
+        experience: 0,
+        attributes: {
+          strength: 15,
+          dexterity: 12,
+          constitution: 14,
+          intelligence: 10,
+          wisdom: 13,
+          charisma: 11
+        },
+        skills: ['Swordsmanship'],
+        inventory: [],
+        currentHealth: 10,
+        maxHealth: 10,
+        worldSlug: 'invalid-world'
+      };
+
+      const response = await request(app)
+        .post('/api/characters')
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .send(characterData)
+        .expect(422);
+
+      expect(response.body.ok).toBe(false);
+      expect(response.body.error.code).toBe(ApiErrorCode.VALIDATION_FAILED);
+      expect(response.body.error.message).toContain('Invalid world');
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+
+    it('should reject character creation without authentication', async () => {
+      const characterData = {
+        name: 'Test Character',
+        race: 'Human',
+        class: 'Warrior',
+        level: 1,
+        experience: 0,
+        attributes: {
+          strength: 15,
+          dexterity: 12,
+          constitution: 14,
+          intelligence: 10,
+          wisdom: 13,
+          charisma: 11
+        },
+        skills: ['Swordsmanship'],
+        inventory: [],
+        currentHealth: 10,
+        maxHealth: 10,
+        worldSlug: 'mystika'
+      };
+
+      const response = await request(app)
+        .post('/api/characters')
+        .send(characterData)
+        .expect(401);
+
+      expect(response.body.ok).toBe(false);
+      expect(response.body.error.code).toBe(ApiErrorCode.UNAUTHORIZED);
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+  });
+
+  describe('Character Listing (GET /api/characters)', () => {
+    it('should list characters for authenticated user', async () => {
+      const mockCharacters = [
+        {
+          id: mockCharacterId,
+          userId: mockUserId,
+          name: 'Character 1',
+          race: 'Human',
+          class: 'Warrior',
+          level: 1,
+          experience: 0,
+          attributes: { strength: 15, dexterity: 12, constitution: 14, intelligence: 10, wisdom: 13, charisma: 11 },
+          skills: ['Swordsmanship'],
+          inventory: [],
+          currentHealth: 10,
+          maxHealth: 10,
+          worldSlug: 'mystika',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
+        }
+      ];
+
+      // Mock successful character listing
+      const mockSupabase = vi.mocked(supabase);
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            order: vi.fn(() => Promise.resolve({ data: mockCharacters, error: null }))
+          }))
+        }))
+      } as any);
+
+      const response = await request(app)
+        .get('/api/characters')
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data).toHaveLength(1);
+      expect(response.body.data[0].id).toBe(mockCharacterId);
+      expect(response.body.data[0].name).toBe('Character 1');
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+
+    it('should list characters for guest user', async () => {
+      const mockCharacters = [
+        {
+          id: mockCharacterId,
+          userId: mockGuestId,
+          name: 'Guest Character',
+          race: 'Elf',
+          class: 'Mage',
+          level: 1,
+          experience: 0,
+          attributes: { strength: 10, dexterity: 14, constitution: 12, intelligence: 16, wisdom: 15, charisma: 13 },
+          skills: ['Magic'],
+          inventory: [],
+          currentHealth: 8,
+          maxHealth: 8,
+          worldSlug: 'aetherium',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
+        }
+      ];
+
+      // Mock successful character listing for guest
+      const mockSupabase = vi.mocked(supabase);
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            order: vi.fn(() => Promise.resolve({ data: mockCharacters, error: null }))
+          }))
+        }))
+      } as any);
+
+      const response = await request(app)
+        .get('/api/characters')
+        .set('Cookie', `guestId=${mockGuestId}`)
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data).toHaveLength(1);
+      expect(response.body.data[0].id).toBe(mockCharacterId);
+      expect(response.body.data[0].name).toBe('Guest Character');
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+
+    it('should reject character listing without authentication', async () => {
+      const response = await request(app)
+        .get('/api/characters')
+        .expect(401);
+
+      expect(response.body.ok).toBe(false);
+      expect(response.body.error.code).toBe(ApiErrorCode.UNAUTHORIZED);
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+  });
+
+  describe('Character Reading (GET /api/characters/:id)', () => {
+    it('should read character for authenticated user', async () => {
+      const mockCharacter = {
+        id: mockCharacterId,
+        userId: mockUserId,
+        name: 'Character 1',
+        race: 'Human',
+        class: 'Warrior',
+        level: 1,
+        experience: 0,
+        attributes: { strength: 15, dexterity: 12, constitution: 14, intelligence: 10, wisdom: 13, charisma: 11 },
+        skills: ['Swordsmanship'],
+        inventory: [],
+        currentHealth: 10,
+        maxHealth: 10,
+        worldSlug: 'mystika',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+
+      // Mock successful character reading
+      const mockSupabase = vi.mocked(supabase);
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve({ data: mockCharacter, error: null }))
+            }))
+          }))
+        }))
+      } as any);
+
+      const response = await request(app)
+        .get(`/api/characters/${mockCharacterId}`)
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data.id).toBe(mockCharacterId);
+      expect(response.body.data.name).toBe('Character 1');
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+
+    it('should reject reading character from different user', async () => {
+      const otherUserId = uuidv4();
+      const mockCharacter = {
+        id: mockCharacterId,
+        userId: otherUserId, // Different user
+        name: 'Other Character',
+        race: 'Human',
+        class: 'Warrior',
+        level: 1,
+        experience: 0,
+        attributes: { strength: 15, dexterity: 12, constitution: 14, intelligence: 10, wisdom: 13, charisma: 11 },
+        skills: ['Swordsmanship'],
+        inventory: [],
+        currentHealth: 10,
+        maxHealth: 10,
+        worldSlug: 'mystika',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+
+      // Mock character found but different owner
+      const mockSupabase = vi.mocked(supabase);
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve({ data: null, error: { code: 'PGRST116' } }))
+            }))
+          }))
+        }))
+      } as any);
+
+      const response = await request(app)
+        .get(`/api/characters/${mockCharacterId}`)
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .expect(404);
+
+      expect(response.body.ok).toBe(false);
+      expect(response.body.error.code).toBe(ApiErrorCode.NOT_FOUND);
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+  });
+
+  describe('Character Update (PATCH /api/characters/:id)', () => {
+    it('should update character for authenticated user', async () => {
+      const updateData = {
+        name: 'Updated Character',
+        level: 2
+      };
+
+      const mockUpdatedCharacter = {
+        id: mockCharacterId,
+        userId: mockUserId,
+        name: 'Updated Character',
+        race: 'Human',
+        class: 'Warrior',
+        level: 2,
+        experience: 0,
+        attributes: { strength: 15, dexterity: 12, constitution: 14, intelligence: 10, wisdom: 13, charisma: 11 },
+        skills: ['Swordsmanship'],
+        inventory: [],
+        currentHealth: 10,
+        maxHealth: 10,
+        worldSlug: 'mystika',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+
+      // Mock successful character update
+      const mockSupabase = vi.mocked(supabase);
+      mockSupabase.from.mockReturnValue({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn(() => Promise.resolve({ data: mockUpdatedCharacter, error: null }))
+              }))
+            }))
+          }))
+        }))
+      } as any);
+
+      const response = await request(app)
+        .patch(`/api/characters/${mockCharacterId}`)
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .send(updateData)
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data.id).toBe(mockCharacterId);
+      expect(response.body.data.name).toBe('Updated Character');
+      expect(response.body.data.level).toBe(2);
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+
+    it('should reject updating character from different user', async () => {
+      const updateData = {
+        name: 'Hacked Character'
+      };
+
+      // Mock update fails due to ownership check
+      const mockSupabase = vi.mocked(supabase);
+      mockSupabase.from.mockReturnValue({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn(() => Promise.resolve({ data: null, error: { code: 'PGRST116' } }))
+              }))
+            }))
+          }))
+        }))
+      } as any);
+
+      const response = await request(app)
+        .patch(`/api/characters/${mockCharacterId}`)
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .send(updateData)
+        .expect(404);
+
+      expect(response.body.ok).toBe(false);
+      expect(response.body.error.code).toBe(ApiErrorCode.NOT_FOUND);
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+  });
+
+  describe('Character Deletion (DELETE /api/characters/:id)', () => {
+    it('should delete character for authenticated user', async () => {
+      // Mock successful character deletion
+      const mockSupabase = vi.mocked(supabase);
+      mockSupabase.from.mockReturnValue({
+        delete: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => Promise.resolve({ error: null }))
+          }))
+        }))
+      } as any);
+
+      const response = await request(app)
+        .delete(`/api/characters/${mockCharacterId}`)
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .expect(204);
+
+      expect(response.body).toEqual({});
+    });
+
+    it('should reject deleting character from different user', async () => {
+      // Mock deletion fails due to ownership check
+      const mockSupabase = vi.mocked(supabase);
+      mockSupabase.from.mockReturnValue({
+        delete: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => Promise.resolve({ error: { code: 'PGRST116' } }))
+          }))
+        }))
+      } as any);
+
+      const response = await request(app)
+        .delete(`/api/characters/${mockCharacterId}`)
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .expect(500);
+
+      expect(response.body.ok).toBe(false);
+      expect(response.body.error.code).toBe(ApiErrorCode.INTERNAL_ERROR);
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+  });
+
+  describe('DTO Redaction', () => {
+    it('should not include internal fields in character responses', async () => {
+      const mockCharacter = {
+        id: mockCharacterId,
+        userId: mockUserId,
+        name: 'Test Character',
+        race: 'Human',
+        class: 'Warrior',
+        level: 1,
+        experience: 0,
+        attributes: { strength: 15, dexterity: 12, constitution: 14, intelligence: 10, wisdom: 13, charisma: 11 },
+        skills: ['Swordsmanship'],
+        inventory: [],
+        currentHealth: 10,
+        maxHealth: 10,
+        worldSlug: 'mystika',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        // Internal fields that should be redacted
+        internalFlags: ['test_flag'],
+        systemMetadata: { source: 'test' }
+      };
+
+      // Mock successful character reading
+      const mockSupabase = vi.mocked(supabase);
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve({ data: mockCharacter, error: null }))
+            }))
+          }))
+        }))
+      } as any);
+
+      const response = await request(app)
+        .get(`/api/characters/${mockCharacterId}`)
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data.id).toBe(mockCharacterId);
+      expect(response.body.data.name).toBe('Test Character');
+      // Internal fields should not be present
+      expect(response.body.data.internalFlags).toBeUndefined();
+      expect(response.body.data.systemMetadata).toBeUndefined();
+      expect(response.body.data.userId).toBeUndefined(); // userId should be redacted
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+  });
+});

--- a/backend/src/routes/stones.m1.test.ts
+++ b/backend/src/routes/stones.m1.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import stonesRouter from './stones.js';
+import { WalletService } from '../services/wallet.service.js';
+import { ApiErrorCode } from 'shared';
+
+// Mock the wallet service
+vi.mock('../services/wallet.service.js', () => ({
+  WalletService: {
+    getWallet: vi.fn(),
+    getOrCreateWallet: vi.fn()
+  }
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/stones', stonesRouter);
+
+describe('Layer M1 - Wallet Read Operations', () => {
+  const mockUserId = uuidv4();
+  const mockGuestId = uuidv4();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Wallet Read (GET /api/stones/wallet)', () => {
+    it('should return casting stones balance for authenticated user', async () => {
+      const mockWallet = {
+        id: uuidv4(),
+        userId: mockUserId,
+        castingStones: 150,
+        inventoryShard: 25,
+        inventoryCrystal: 10,
+        inventoryRelic: 2,
+        dailyRegen: 5,
+        lastRegenAt: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+
+      // Mock successful wallet retrieval
+      vi.mocked(WalletService.getWallet).mockResolvedValue(mockWallet);
+
+      const response = await request(app)
+        .get('/api/stones/wallet')
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data).toEqual({
+        shard: 25,
+        crystal: 10,
+        relic: 2,
+        dailyRegen: 5,
+        lastRegenAt: mockWallet.lastRegenAt
+      });
+      expect(response.body.meta.traceId).toBeDefined();
+      expect(WalletService.getWallet).toHaveBeenCalledWith(mockUserId);
+    });
+
+    it('should return empty wallet for guest user', async () => {
+      const response = await request(app)
+        .get('/api/stones/wallet')
+        .set('Cookie', `guestId=${mockGuestId}`)
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data).toEqual({
+        shard: 0,
+        crystal: 0,
+        relic: 0,
+        dailyRegen: 0,
+        lastRegenAt: undefined
+      });
+      expect(response.body.meta.traceId).toBeDefined();
+      // WalletService should not be called for guests
+      expect(WalletService.getWallet).not.toHaveBeenCalled();
+    });
+
+    it('should reject wallet access without authentication', async () => {
+      const response = await request(app)
+        .get('/api/stones/wallet')
+        .expect(401);
+
+      expect(response.body.ok).toBe(false);
+      expect(response.body.error.code).toBe(ApiErrorCode.UNAUTHORIZED);
+      expect(response.body.error.message).toContain('Authentication required');
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+
+    it('should handle wallet service errors gracefully', async () => {
+      // Mock wallet service error
+      vi.mocked(WalletService.getWallet).mockRejectedValue(new Error('Database connection failed'));
+
+      const response = await request(app)
+        .get('/api/stones/wallet')
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .expect(500);
+
+      expect(response.body.ok).toBe(false);
+      expect(response.body.error.code).toBe(ApiErrorCode.INTERNAL_ERROR);
+      expect(response.body.error.message).toContain('Failed to fetch stones wallet');
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+
+    it('should return wallet with zero balance for new user', async () => {
+      const mockWallet = {
+        id: uuidv4(),
+        userId: mockUserId,
+        castingStones: 0,
+        inventoryShard: 0,
+        inventoryCrystal: 0,
+        inventoryRelic: 0,
+        dailyRegen: 0,
+        lastRegenAt: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+
+      // Mock successful wallet retrieval with zero balance
+      vi.mocked(WalletService.getWallet).mockResolvedValue(mockWallet);
+
+      const response = await request(app)
+        .get('/api/stones/wallet')
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data).toEqual({
+        shard: 0,
+        crystal: 0,
+        relic: 0,
+        dailyRegen: 0,
+        lastRegenAt: mockWallet.lastRegenAt
+      });
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+
+    it('should return wallet with high balance for premium user', async () => {
+      const mockWallet = {
+        id: uuidv4(),
+        userId: mockUserId,
+        castingStones: 5000,
+        inventoryShard: 1000,
+        inventoryCrystal: 500,
+        inventoryRelic: 100,
+        dailyRegen: 50,
+        lastRegenAt: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+
+      // Mock successful wallet retrieval with high balance
+      vi.mocked(WalletService.getWallet).mockResolvedValue(mockWallet);
+
+      const response = await request(app)
+        .get('/api/stones/wallet')
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data).toEqual({
+        shard: 1000,
+        crystal: 500,
+        relic: 100,
+        dailyRegen: 50,
+        lastRegenAt: mockWallet.lastRegenAt
+      });
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+  });
+
+  describe('Wallet DTO Redaction', () => {
+    it('should not include internal wallet fields in response', async () => {
+      const mockWallet = {
+        id: uuidv4(),
+        userId: mockUserId,
+        castingStones: 150,
+        inventoryShard: 25,
+        inventoryCrystal: 10,
+        inventoryRelic: 2,
+        dailyRegen: 5,
+        lastRegenAt: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        // Internal fields that should be redacted
+        internalFlags: ['premium_user'],
+        systemMetadata: { source: 'migration' },
+        auditTrail: ['created', 'updated']
+      };
+
+      // Mock successful wallet retrieval
+      vi.mocked(WalletService.getWallet).mockResolvedValue(mockWallet);
+
+      const response = await request(app)
+        .get('/api/stones/wallet')
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data).toEqual({
+        shard: 25,
+        crystal: 10,
+        relic: 2,
+        dailyRegen: 5,
+        lastRegenAt: mockWallet.lastRegenAt
+      });
+      // Internal fields should not be present
+      expect(response.body.data.id).toBeUndefined();
+      expect(response.body.data.userId).toBeUndefined();
+      expect(response.body.data.castingStones).toBeUndefined();
+      expect(response.body.data.internalFlags).toBeUndefined();
+      expect(response.body.data.systemMetadata).toBeUndefined();
+      expect(response.body.data.auditTrail).toBeUndefined();
+      expect(response.body.data.createdAt).toBeUndefined();
+      expect(response.body.data.updatedAt).toBeUndefined();
+      expect(response.body.meta.traceId).toBeDefined();
+    });
+  });
+
+  describe('Response Envelope Compliance', () => {
+    it('should include traceId in all responses', async () => {
+      const mockWallet = {
+        id: uuidv4(),
+        userId: mockUserId,
+        castingStones: 100,
+        inventoryShard: 20,
+        inventoryCrystal: 5,
+        inventoryRelic: 1,
+        dailyRegen: 3,
+        lastRegenAt: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+
+      vi.mocked(WalletService.getWallet).mockResolvedValue(mockWallet);
+
+      const response = await request(app)
+        .get('/api/stones/wallet')
+        .set('Authorization', `Bearer valid-jwt-token`)
+        .expect(200);
+
+      expect(response.body.meta).toBeDefined();
+      expect(response.body.meta.traceId).toBeDefined();
+      expect(typeof response.body.meta.traceId).toBe('string');
+      // Should be a valid UUID
+      expect(response.body.meta.traceId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+    });
+
+    it('should include traceId in error responses', async () => {
+      const response = await request(app)
+        .get('/api/stones/wallet')
+        .expect(401);
+
+      expect(response.body.meta).toBeDefined();
+      expect(response.body.meta.traceId).toBeDefined();
+      expect(typeof response.body.meta.traceId).toBe('string');
+      expect(response.body.meta.traceId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+    });
+  });
+});

--- a/backend/src/routes/stones.ts
+++ b/backend/src/routes/stones.ts
@@ -11,28 +11,18 @@ import { PaymentService } from '../wrappers/payments.js';
 
 const router = Router();
 
-// Get stones wallet (auth or guest)
-router.get('/wallet', jwtAuth, async (req: Request, res: Response) => {
+// Get stones wallet (auth only in M1)
+router.get('/wallet', jwtAuth, requireAuth, async (req: Request, res: Response) => {
   try {
     const userId = req.ctx?.userId;
     
     if (!userId) {
-      // Guest user - return empty wallet with casting stones only
-      const guestWallet = {
-        id: 'guest',
-        userId: 'guest',
-        castingStones: 0,
-        inventoryShard: 0,
-        inventoryCrystal: 0,
-        inventoryRelic: 0,
-        dailyRegen: 0,
-        lastRegenAt: undefined,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      };
-      const walletDTO = toStonesWalletDTO(guestWallet);
-      sendSuccess(res, walletDTO, req);
-      return;
+      return sendErrorWithStatus(
+        res,
+        ApiErrorCode.UNAUTHORIZED,
+        'Authentication required',
+        req
+      );
     }
 
     // Authenticated user - get full wallet

--- a/backend/src/services/characters.service.ts
+++ b/backend/src/services/characters.service.ts
@@ -1,0 +1,396 @@
+import { supabaseAdmin } from './supabase.js';
+import { WorldValidationService } from './worldValidation.service.js';
+import type { Character } from 'shared';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface CreateCharacterInput {
+  name: string;
+  race: string;
+  class: string;
+  level?: number;
+  experience?: number;
+  attributes: {
+    strength: number;
+    dexterity: number;
+    constitution: number;
+    intelligence: number;
+    wisdom: number;
+    charisma: number;
+  };
+  skills?: string[];
+  inventory?: Array<{
+    id: string;
+    name: string;
+    description: string;
+    quantity: number;
+  }>;
+  currentHealth?: number;
+  maxHealth?: number;
+  worldSlug: string;
+}
+
+export interface UpdateCharacterInput {
+  name?: string;
+  race?: string;
+  class?: string;
+  level?: number;
+  experience?: number;
+  attributes?: {
+    strength?: number;
+    dexterity?: number;
+    constitution?: number;
+    intelligence?: number;
+    wisdom?: number;
+    charisma?: number;
+  };
+  skills?: string[];
+  inventory?: Array<{
+    id: string;
+    name: string;
+    description: string;
+    quantity: number;
+  }>;
+  currentHealth?: number;
+  maxHealth?: number;
+  worldSlug?: string;
+}
+
+export interface CharacterQueryOptions {
+  userId?: string;
+  cookieId?: string;
+  worldSlug?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * Characters Service - manages character CRUD operations
+ * Handles both authenticated users and guest users via cookies
+ */
+export class CharactersService {
+  /**
+   * Create a new character
+   */
+  static async createCharacter(
+    input: CreateCharacterInput,
+    ownerId: string,
+    isGuest: boolean = false
+  ): Promise<Character> {
+    try {
+      // Validate world slug
+      const worldValidation = await WorldValidationService.validateWorldSlug(input.worldSlug);
+      if (!worldValidation.isValid) {
+        throw new Error(worldValidation.error || 'Invalid world slug');
+      }
+
+      // Calculate health if not provided
+      const currentHealth = input.currentHealth ?? input.maxHealth ?? this.calculateMaxHealth(input.attributes.constitution);
+      const maxHealth = input.maxHealth ?? this.calculateMaxHealth(input.attributes.constitution);
+
+      const characterData = {
+        id: uuidv4(),
+        name: input.name,
+        race: input.race,
+        class: input.class,
+        level: input.level ?? 1,
+        experience: input.experience ?? 0,
+        attributes: input.attributes,
+        skills: input.skills ?? [],
+        inventory: input.inventory ?? [],
+        current_health: currentHealth,
+        max_health: maxHealth,
+        world_slug: input.worldSlug,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        // Set owner based on user type
+        ...(isGuest ? { cookie_id: ownerId } : { user_id: ownerId })
+      };
+
+      const { data, error } = await supabaseAdmin
+        .from('characters')
+        .insert([characterData])
+        .select()
+        .single();
+
+      if (error) {
+        console.error('Error creating character:', error);
+        throw new Error(`Failed to create character: ${error.message}`);
+      }
+
+      return this.mapCharacterFromDb(data);
+    } catch (error) {
+      console.error('CharactersService.createCharacter error:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get characters for a user
+   */
+  static async getCharacters(
+    ownerId: string,
+    isGuest: boolean = false,
+    options: CharacterQueryOptions = {}
+  ): Promise<Character[]> {
+    try {
+      let query = supabaseAdmin
+        .from('characters')
+        .select('*')
+        .order('created_at', { ascending: false });
+
+      // Filter by owner
+      if (isGuest) {
+        query = query.eq('cookie_id', ownerId);
+      } else {
+        query = query.eq('user_id', ownerId);
+      }
+
+      // Additional filters
+      if (options.worldSlug) {
+        query = query.eq('world_slug', options.worldSlug);
+      }
+
+      if (options.limit) {
+        query = query.limit(options.limit);
+      }
+
+      if (options.offset) {
+        query = query.range(options.offset, options.offset + (options.limit || 50) - 1);
+      }
+
+      const { data, error } = await query;
+
+      if (error) {
+        console.error('Error fetching characters:', error);
+        throw new Error(`Failed to fetch characters: ${error.message}`);
+      }
+
+      return (data || []).map(this.mapCharacterFromDb);
+    } catch (error) {
+      console.error('CharactersService.getCharacters error:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get a single character by ID
+   */
+  static async getCharacterById(
+    characterId: string,
+    ownerId: string,
+    isGuest: boolean = false
+  ): Promise<Character | null> {
+    try {
+      let query = supabaseAdmin
+        .from('characters')
+        .select('*')
+        .eq('id', characterId);
+
+      // Filter by owner
+      if (isGuest) {
+        query = query.eq('cookie_id', ownerId);
+      } else {
+        query = query.eq('user_id', ownerId);
+      }
+
+      const { data, error } = await query.single();
+
+      if (error) {
+        if (error.code === 'PGRST116') {
+          // No rows returned - character not found or not owned by user
+          return null;
+        }
+        console.error('Error fetching character:', error);
+        throw new Error(`Failed to fetch character: ${error.message}`);
+      }
+
+      return this.mapCharacterFromDb(data);
+    } catch (error) {
+      console.error('CharactersService.getCharacterById error:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Update a character
+   */
+  static async updateCharacter(
+    characterId: string,
+    input: UpdateCharacterInput,
+    ownerId: string,
+    isGuest: boolean = false
+  ): Promise<Character | null> {
+    try {
+      // Validate world slug if provided
+      if (input.worldSlug) {
+        const worldValidation = await WorldValidationService.validateWorldSlug(input.worldSlug);
+        if (!worldValidation.isValid) {
+          throw new Error(worldValidation.error || 'Invalid world slug');
+        }
+      }
+
+      const updateData: any = {
+        updated_at: new Date().toISOString(),
+      };
+
+      // Only include fields that are provided
+      if (input.name !== undefined) updateData.name = input.name;
+      if (input.race !== undefined) updateData.race = input.race;
+      if (input.class !== undefined) updateData.class = input.class;
+      if (input.level !== undefined) updateData.level = input.level;
+      if (input.experience !== undefined) updateData.experience = input.experience;
+      if (input.attributes !== undefined) updateData.attributes = input.attributes;
+      if (input.skills !== undefined) updateData.skills = input.skills;
+      if (input.inventory !== undefined) updateData.inventory = input.inventory;
+      if (input.currentHealth !== undefined) updateData.current_health = input.currentHealth;
+      if (input.maxHealth !== undefined) updateData.max_health = input.maxHealth;
+      if (input.worldSlug !== undefined) updateData.world_slug = input.worldSlug;
+
+      let query = supabaseAdmin
+        .from('characters')
+        .update(updateData)
+        .eq('id', characterId);
+
+      // Filter by owner
+      if (isGuest) {
+        query = query.eq('cookie_id', ownerId);
+      } else {
+        query = query.eq('user_id', ownerId);
+      }
+
+      const { data, error } = await query.select().single();
+
+      if (error) {
+        if (error.code === 'PGRST116') {
+          // No rows returned - character not found or not owned by user
+          return null;
+        }
+        console.error('Error updating character:', error);
+        throw new Error(`Failed to update character: ${error.message}`);
+      }
+
+      return this.mapCharacterFromDb(data);
+    } catch (error) {
+      console.error('CharactersService.updateCharacter error:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Delete a character
+   */
+  static async deleteCharacter(
+    characterId: string,
+    ownerId: string,
+    isGuest: boolean = false
+  ): Promise<boolean> {
+    try {
+      let query = supabaseAdmin
+        .from('characters')
+        .delete()
+        .eq('id', characterId);
+
+      // Filter by owner
+      if (isGuest) {
+        query = query.eq('cookie_id', ownerId);
+      } else {
+        query = query.eq('user_id', ownerId);
+      }
+
+      const { error } = await query;
+
+      if (error) {
+        console.error('Error deleting character:', error);
+        throw new Error(`Failed to delete character: ${error.message}`);
+      }
+
+      return true;
+    } catch (error) {
+      console.error('CharactersService.deleteCharacter error:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Check if a character exists and is owned by the user
+   */
+  static async isCharacterOwnedBy(
+    characterId: string,
+    ownerId: string,
+    isGuest: boolean = false
+  ): Promise<boolean> {
+    try {
+      const character = await this.getCharacterById(characterId, ownerId, isGuest);
+      return character !== null;
+    } catch (error) {
+      console.error('CharactersService.isCharacterOwnedBy error:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Get character count for a user
+   */
+  static async getCharacterCount(
+    ownerId: string,
+    isGuest: boolean = false
+  ): Promise<number> {
+    try {
+      let query = supabaseAdmin
+        .from('characters')
+        .select('id', { count: 'exact' });
+
+      // Filter by owner
+      if (isGuest) {
+        query = query.eq('cookie_id', ownerId);
+      } else {
+        query = query.eq('user_id', ownerId);
+      }
+
+      const { count, error } = await query;
+
+      if (error) {
+        console.error('Error counting characters:', error);
+        throw new Error(`Failed to count characters: ${error.message}`);
+      }
+
+      return count || 0;
+    } catch (error) {
+      console.error('CharactersService.getCharacterCount error:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Calculate max health based on constitution
+   */
+  private static calculateMaxHealth(constitution: number): number {
+    // Basic formula: 8 + constitution modifier
+    const modifier = Math.floor((constitution - 10) / 2);
+    return Math.max(1, 8 + modifier);
+  }
+
+  /**
+   * Map database row to Character type
+   */
+  private static mapCharacterFromDb(dbRow: any): Character {
+    return {
+      id: dbRow.id,
+      userId: dbRow.user_id || undefined,
+      cookieId: dbRow.cookie_id || undefined,
+      name: dbRow.name,
+      race: dbRow.race,
+      class: dbRow.class,
+      level: dbRow.level,
+      experience: dbRow.experience,
+      attributes: dbRow.attributes,
+      skills: dbRow.skills,
+      inventory: dbRow.inventory,
+      currentHealth: dbRow.current_health,
+      maxHealth: dbRow.max_health,
+      worldSlug: dbRow.world_slug,
+      createdAt: dbRow.created_at,
+      updatedAt: dbRow.updated_at,
+    };
+  }
+}

--- a/backend/src/services/worldValidation.m1.test.ts
+++ b/backend/src/services/worldValidation.m1.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { WorldValidationService } from './worldValidation.service.js';
+import { ContentService } from './content.service.js';
+
+// Mock the content service
+vi.mock('./content.service.js', () => ({
+  ContentService: {
+    getWorlds: vi.fn()
+  }
+}));
+
+describe('Layer M1 - World Validation Service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('World Slug Validation', () => {
+    it('should validate valid world slug', async () => {
+      const mockWorlds = [
+        { slug: 'mystika', name: 'Mystika' },
+        { slug: 'aetherium', name: 'Aetherium' },
+        { slug: 'voidreach', name: 'Voidreach' },
+        { slug: 'whispercross', name: 'Whispercross Glade' },
+        { slug: 'paragon-city', name: 'Paragon City' },
+        { slug: 'veloria', name: 'Veloria - Court of Hearts' },
+        { slug: 'noctis-veil', name: 'Noctis Veil' }
+      ];
+
+      vi.mocked(ContentService.getWorlds).mockResolvedValue(mockWorlds);
+
+      const result = await WorldValidationService.validateWorldSlug('mystika');
+      expect(result.isValid).toBe(true);
+      expect(result.world).toEqual({ slug: 'mystika', name: 'Mystika' });
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should reject invalid world slug', async () => {
+      const mockWorlds = [
+        { slug: 'mystika', name: 'Mystika' },
+        { slug: 'aetherium', name: 'Aetherium' },
+        { slug: 'voidreach', name: 'Voidreach' }
+      ];
+
+      vi.mocked(ContentService.getWorlds).mockResolvedValue(mockWorlds);
+
+      const result = await WorldValidationService.validateWorldSlug('invalid-world');
+      expect(result.isValid).toBe(false);
+      expect(result.world).toBeUndefined();
+      expect(result.error).toBe('Invalid world slug: invalid-world');
+    });
+
+    it('should reject empty world slug', async () => {
+      const mockWorlds = [
+        { slug: 'mystika', name: 'Mystika' },
+        { slug: 'aetherium', name: 'Aetherium' }
+      ];
+
+      vi.mocked(ContentService.getWorlds).mockResolvedValue(mockWorlds);
+
+      const result = await WorldValidationService.validateWorldSlug('');
+      expect(result.isValid).toBe(false);
+      expect(result.world).toBeUndefined();
+      expect(result.error).toBe('World slug is required');
+    });
+
+    it('should reject null world slug', async () => {
+      const mockWorlds = [
+        { slug: 'mystika', name: 'Mystika' }
+      ];
+
+      vi.mocked(ContentService.getWorlds).mockResolvedValue(mockWorlds);
+
+      const result = await WorldValidationService.validateWorldSlug(null as any);
+      expect(result.isValid).toBe(false);
+      expect(result.world).toBeUndefined();
+      expect(result.error).toBe('World slug is required');
+    });
+
+    it('should reject undefined world slug', async () => {
+      const mockWorlds = [
+        { slug: 'mystika', name: 'Mystika' }
+      ];
+
+      vi.mocked(ContentService.getWorlds).mockResolvedValue(mockWorlds);
+
+      const result = await WorldValidationService.validateWorldSlug(undefined as any);
+      expect(result.isValid).toBe(false);
+      expect(result.world).toBeUndefined();
+      expect(result.error).toBe('World slug is required');
+    });
+
+    it('should handle case sensitivity correctly', async () => {
+      const mockWorlds = [
+        { slug: 'mystika', name: 'Mystika' },
+        { slug: 'aetherium', name: 'Aetherium' }
+      ];
+
+      vi.mocked(ContentService.getWorlds).mockResolvedValue(mockWorlds);
+
+      // Should reject uppercase
+      const result1 = await WorldValidationService.validateWorldSlug('MYSTIKA');
+      expect(result1.isValid).toBe(false);
+      expect(result1.error).toBe('Invalid world slug: MYSTIKA');
+
+      // Should reject mixed case
+      const result2 = await WorldValidationService.validateWorldSlug('Mystika');
+      expect(result2.isValid).toBe(false);
+      expect(result2.error).toBe('Invalid world slug: Mystika');
+    });
+
+    it('should handle content service errors gracefully', async () => {
+      vi.mocked(ContentService.getWorlds).mockRejectedValue(new Error('Failed to load worlds'));
+
+      const result = await WorldValidationService.validateWorldSlug('mystika');
+      expect(result.isValid).toBe(false);
+      expect(result.world).toBeUndefined();
+      expect(result.error).toBe('Failed to validate world slug: Failed to load worlds');
+    });
+
+    it('should handle empty worlds list', async () => {
+      vi.mocked(ContentService.getWorlds).mockResolvedValue([]);
+
+      const result = await WorldValidationService.validateWorldSlug('mystika');
+      expect(result.isValid).toBe(false);
+      expect(result.world).toBeUndefined();
+      expect(result.error).toBe('Invalid world slug: mystika');
+    });
+
+    it('should validate all available world slugs', async () => {
+      const mockWorlds = [
+        { slug: 'mystika', name: 'Mystika' },
+        { slug: 'aetherium', name: 'Aetherium' },
+        { slug: 'voidreach', name: 'Voidreach' },
+        { slug: 'whispercross', name: 'Whispercross Glade' },
+        { slug: 'paragon-city', name: 'Paragon City' },
+        { slug: 'veloria', name: 'Veloria - Court of Hearts' },
+        { slug: 'noctis-veil', name: 'Noctis Veil' }
+      ];
+
+      vi.mocked(ContentService.getWorlds).mockResolvedValue(mockWorlds);
+
+      // Test all valid slugs
+      for (const world of mockWorlds) {
+        const result = await WorldValidationService.validateWorldSlug(world.slug);
+        expect(result.isValid).toBe(true);
+        expect(result.world).toEqual(world);
+        expect(result.error).toBeUndefined();
+      }
+    });
+
+    it('should cache world data for performance', async () => {
+      const mockWorlds = [
+        { slug: 'mystika', name: 'Mystika' },
+        { slug: 'aetherium', name: 'Aetherium' }
+      ];
+
+      vi.mocked(ContentService.getWorlds).mockResolvedValue(mockWorlds);
+
+      // First call should fetch from content service
+      const result1 = await WorldValidationService.validateWorldSlug('mystika');
+      expect(result1.isValid).toBe(true);
+      expect(contentService.getWorlds).toHaveBeenCalledTimes(1);
+
+      // Second call should use cache
+      const result2 = await WorldValidationService.validateWorldSlug('aetherium');
+      expect(result2.isValid).toBe(true);
+      expect(contentService.getWorlds).toHaveBeenCalledTimes(1); // Still 1, not 2
+    });
+
+    it('should handle special characters in world slugs', async () => {
+      const mockWorlds = [
+        { slug: 'paragon-city', name: 'Paragon City' },
+        { slug: 'noctis-veil', name: 'Noctis Veil' }
+      ];
+
+      vi.mocked(ContentService.getWorlds).mockResolvedValue(mockWorlds);
+
+      // Should accept hyphens
+      const result1 = await WorldValidationService.validateWorldSlug('paragon-city');
+      expect(result1.isValid).toBe(true);
+      expect(result1.world).toEqual({ slug: 'paragon-city', name: 'Paragon City' });
+
+      // Should accept hyphens
+      const result2 = await WorldValidationService.validateWorldSlug('noctis-veil');
+      expect(result2.isValid).toBe(true);
+      expect(result2.world).toEqual({ slug: 'noctis-veil', name: 'Noctis Veil' });
+    });
+  });
+
+  describe('World Data Retrieval', () => {
+    it('should return world data for valid slug', async () => {
+      const mockWorlds = [
+        { slug: 'mystika', name: 'Mystika', description: 'A realm where the Veil between worlds has grown thin' },
+        { slug: 'aetherium', name: 'Aetherium', description: 'In the sprawling neon-lit megacities of Aetherium' }
+      ];
+
+      vi.mocked(ContentService.getWorlds).mockResolvedValue(mockWorlds);
+
+      const result = await WorldValidationService.getWorldData('mystika');
+      expect(result).toEqual({
+        slug: 'mystika',
+        name: 'Mystika',
+        description: 'A realm where the Veil between worlds has grown thin'
+      });
+    });
+
+    it('should return null for invalid slug', async () => {
+      const mockWorlds = [
+        { slug: 'mystika', name: 'Mystika' }
+      ];
+
+      vi.mocked(ContentService.getWorlds).mockResolvedValue(mockWorlds);
+
+      const result = await WorldValidationService.getWorldData('invalid-world');
+      expect(result).toBeNull();
+    });
+
+    it('should handle content service errors in getWorldData', async () => {
+      vi.mocked(ContentService.getWorlds).mockRejectedValue(new Error('Failed to load worlds'));
+
+      const result = await WorldValidationService.getWorldData('mystika');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/backend/src/services/worldValidation.service.ts
+++ b/backend/src/services/worldValidation.service.ts
@@ -1,0 +1,139 @@
+import { ContentService } from './content.service.js';
+
+export interface WorldValidationResult {
+  isValid: boolean;
+  world?: {
+    slug: string;
+    name: string;
+    description?: string;
+  };
+  error?: string;
+}
+
+export interface WorldData {
+  slug: string;
+  name: string;
+  description?: string;
+  rules?: any[];
+  tags?: string[];
+  adventures?: any[];
+}
+
+/**
+ * World Validation Service - validates world slugs against static content
+ * Provides caching for performance and handles all world-related validation
+ */
+export class WorldValidationService {
+  private static worldCache: WorldData[] | null = null;
+  private static cacheTimestamp: number = 0;
+  private static readonly CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+  /**
+   * Validate a world slug against available worlds
+   */
+  static async validateWorldSlug(worldSlug: string | null | undefined): Promise<WorldValidationResult> {
+    try {
+      // Check if worldSlug is provided
+      if (!worldSlug || typeof worldSlug !== 'string' || worldSlug.trim() === '') {
+        return {
+          isValid: false,
+          error: 'World slug is required'
+        };
+      }
+
+      // Get worlds (with caching)
+      const worlds = await this.getWorlds();
+      
+      // Find matching world
+      const world = worlds.find(w => w.slug === worldSlug);
+      
+      if (!world) {
+        return {
+          isValid: false,
+          error: `Invalid world slug: ${worldSlug}`
+        };
+      }
+
+      return {
+        isValid: true,
+        world: {
+          slug: world.slug,
+          name: world.name,
+          description: world.description
+        }
+      };
+    } catch (error) {
+      console.error('WorldValidationService.validateWorldSlug error:', error);
+      return {
+        isValid: false,
+        error: `Failed to validate world slug: ${error instanceof Error ? error.message : 'Unknown error'}`
+      };
+    }
+  }
+
+  /**
+   * Get world data by slug
+   */
+  static async getWorldData(worldSlug: string): Promise<WorldData | null> {
+    try {
+      const worlds = await this.getWorlds();
+      return worlds.find(w => w.slug === worldSlug) || null;
+    } catch (error) {
+      console.error('WorldValidationService.getWorldData error:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Get all available worlds with caching
+   */
+  private static async getWorlds(): Promise<WorldData[]> {
+    const now = Date.now();
+    
+    // Return cached data if still valid
+    if (this.worldCache && (now - this.cacheTimestamp) < this.CACHE_TTL) {
+      return this.worldCache;
+    }
+
+    try {
+      // Fetch fresh data from content service
+      const worlds = await ContentService.getWorlds();
+      
+      // Update cache
+      this.worldCache = worlds;
+      this.cacheTimestamp = now;
+      
+      return worlds;
+    } catch (error) {
+      console.error('WorldValidationService.getWorlds error:', error);
+      
+      // Return cached data if available, even if expired
+      if (this.worldCache) {
+        console.warn('Using expired world cache due to content service error');
+        return this.worldCache;
+      }
+      
+      throw error;
+    }
+  }
+
+  /**
+   * Clear the world cache (useful for testing)
+   */
+  static clearCache(): void {
+    this.worldCache = null;
+    this.cacheTimestamp = 0;
+  }
+
+  /**
+   * Get cache status (useful for testing)
+   */
+  static getCacheStatus(): { hasCache: boolean; isExpired: boolean; age: number } {
+    const now = Date.now();
+    const hasCache = this.worldCache !== null;
+    const isExpired = hasCache && (now - this.cacheTimestamp) >= this.CACHE_TTL;
+    const age = hasCache ? now - this.cacheTimestamp : 0;
+    
+    return { hasCache, isExpired, age };
+  }
+}

--- a/backend/src/utils/dto-mappers.m1.test.ts
+++ b/backend/src/utils/dto-mappers.m1.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect } from 'vitest';
+import { toCharacterDTO, toStonesWalletDTO } from './dto-mappers.js';
+import type { Character, StoneWallet } from 'shared';
+
+describe('Layer M1 - DTO Redaction and Envelope Compliance', () => {
+  describe('Character DTO Redaction', () => {
+    it('should redact internal fields from character data', () => {
+      const mockCharacter: Character = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        userId: '987fcdeb-51a2-43d7-8f9e-123456789abc',
+        name: 'Test Character',
+        race: 'Human',
+        class: 'Warrior',
+        level: 1,
+        experience: 0,
+        attributes: {
+          strength: 15,
+          dexterity: 12,
+          constitution: 14,
+          intelligence: 10,
+          wisdom: 13,
+          charisma: 11
+        },
+        skills: ['Swordsmanship'],
+        inventory: [
+          {
+            id: 'item-1',
+            name: 'Iron Sword',
+            description: 'A basic iron sword',
+            quantity: 1
+          }
+        ],
+        currentHealth: 10,
+        maxHealth: 10,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z'
+      };
+
+      const dto = toCharacterDTO(mockCharacter);
+
+      // Should include public fields
+      expect(dto.id).toBe('123e4567-e89b-12d3-a456-426614174000');
+      expect(dto.name).toBe('Test Character');
+      expect(dto.race).toBe('Human');
+      expect(dto.class).toBe('Warrior');
+      expect(dto.level).toBe(1);
+      expect(dto.experience).toBe(0);
+      expect(dto.attributes).toEqual({
+        strength: 15,
+        dexterity: 12,
+        constitution: 14,
+        intelligence: 10,
+        wisdom: 13,
+        charisma: 11
+      });
+      expect(dto.skills).toEqual(['Swordsmanship']);
+      expect(dto.inventory).toEqual([
+        {
+          id: 'item-1',
+          name: 'Iron Sword',
+          description: 'A basic iron sword',
+          quantity: 1
+        }
+      ]);
+      expect(dto.currentHealth).toBe(10);
+      expect(dto.maxHealth).toBe(10);
+      expect(dto.createdAt).toBe('2024-01-01T00:00:00.000Z');
+      expect(dto.updatedAt).toBe('2024-01-01T00:00:00.000Z');
+
+      // Should NOT include internal fields
+      expect((dto as any).userId).toBeUndefined();
+    });
+
+    it('should handle character with minimal data', () => {
+      const mockCharacter: Character = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        userId: '987fcdeb-51a2-43d7-8f9e-123456789abc',
+        name: 'Minimal Character',
+        race: 'Elf',
+        class: 'Mage',
+        level: 1,
+        experience: 0,
+        attributes: {
+          strength: 10,
+          dexterity: 14,
+          constitution: 12,
+          intelligence: 16,
+          wisdom: 15,
+          charisma: 13
+        },
+        skills: [],
+        inventory: [],
+        currentHealth: 8,
+        maxHealth: 8,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z'
+      };
+
+      const dto = toCharacterDTO(mockCharacter);
+
+      expect(dto.id).toBe('123e4567-e89b-12d3-a456-426614174000');
+      expect(dto.name).toBe('Minimal Character');
+      expect(dto.race).toBe('Elf');
+      expect(dto.class).toBe('Mage');
+      expect(dto.skills).toEqual([]);
+      expect(dto.inventory).toEqual([]);
+      expect((dto as any).userId).toBeUndefined();
+    });
+
+    it('should handle character with complex inventory', () => {
+      const mockCharacter: Character = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        userId: '987fcdeb-51a2-43d7-8f9e-123456789abc',
+        name: 'Rich Character',
+        race: 'Dwarf',
+        class: 'Rogue',
+        level: 5,
+        experience: 2500,
+        attributes: {
+          strength: 14,
+          dexterity: 18,
+          constitution: 16,
+          intelligence: 12,
+          wisdom: 13,
+          charisma: 10
+        },
+        skills: ['Stealth', 'Lockpicking', 'Trap Disarming'],
+        inventory: [
+          {
+            id: 'item-1',
+            name: 'Thieves Tools',
+            description: 'A set of professional lockpicking tools',
+            quantity: 1
+          },
+          {
+            id: 'item-2',
+            name: 'Health Potion',
+            description: 'A magical potion that restores health',
+            quantity: 3
+          },
+          {
+            id: 'item-3',
+            name: 'Gold Coins',
+            description: 'Standard currency',
+            quantity: 150
+          }
+        ],
+        currentHealth: 35,
+        maxHealth: 40,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T12:00:00.000Z'
+      };
+
+      const dto = toCharacterDTO(mockCharacter);
+
+      expect(dto.inventory).toHaveLength(3);
+      expect(dto.inventory[0]).toEqual({
+        id: 'item-1',
+        name: 'Thieves Tools',
+        description: 'A set of professional lockpicking tools',
+        quantity: 1
+      });
+      expect(dto.inventory[1]).toEqual({
+        id: 'item-2',
+        name: 'Health Potion',
+        description: 'A magical potion that restores health',
+        quantity: 3
+      });
+      expect(dto.inventory[2]).toEqual({
+        id: 'item-3',
+        name: 'Gold Coins',
+        description: 'Standard currency',
+        quantity: 150
+      });
+      expect((dto as any).userId).toBeUndefined();
+    });
+  });
+
+  describe('Stones Wallet DTO Redaction', () => {
+    it('should redact internal fields from wallet data', () => {
+      const mockWallet: StoneWallet = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        userId: '987fcdeb-51a2-43d7-8f9e-123456789abc',
+        castingStones: 150,
+        inventoryShard: 25,
+        inventoryCrystal: 10,
+        inventoryRelic: 2,
+        dailyRegen: 5,
+        lastRegenAt: '2024-01-01T00:00:00.000Z',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z'
+      };
+
+      const dto = toStonesWalletDTO(mockWallet);
+
+      // Should include public fields
+      expect(dto.shard).toBe(25);
+      expect(dto.crystal).toBe(10);
+      expect(dto.relic).toBe(2);
+      expect(dto.dailyRegen).toBe(5);
+      expect(dto.lastRegenAt).toBe('2024-01-01T00:00:00.000Z');
+
+      // Should NOT include internal fields
+      expect((dto as any).id).toBeUndefined();
+      expect((dto as any).userId).toBeUndefined();
+      expect((dto as any).castingStones).toBeUndefined();
+      expect((dto as any).createdAt).toBeUndefined();
+      expect((dto as any).updatedAt).toBeUndefined();
+    });
+
+    it('should handle wallet with zero balance', () => {
+      const mockWallet: StoneWallet = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        userId: '987fcdeb-51a2-43d7-8f9e-123456789abc',
+        castingStones: 0,
+        inventoryShard: 0,
+        inventoryCrystal: 0,
+        inventoryRelic: 0,
+        dailyRegen: 0,
+        lastRegenAt: '2024-01-01T00:00:00.000Z',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z'
+      };
+
+      const dto = toStonesWalletDTO(mockWallet);
+
+      expect(dto.shard).toBe(0);
+      expect(dto.crystal).toBe(0);
+      expect(dto.relic).toBe(0);
+      expect(dto.dailyRegen).toBe(0);
+      expect(dto.lastRegenAt).toBe('2024-01-01T00:00:00.000Z');
+      expect((dto as any).id).toBeUndefined();
+      expect((dto as any).userId).toBeUndefined();
+      expect((dto as any).castingStones).toBeUndefined();
+    });
+
+    it('should handle wallet with high balance', () => {
+      const mockWallet: StoneWallet = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        userId: '987fcdeb-51a2-43d7-8f9e-123456789abc',
+        castingStones: 5000,
+        inventoryShard: 1000,
+        inventoryCrystal: 500,
+        inventoryRelic: 100,
+        dailyRegen: 50,
+        lastRegenAt: '2024-01-01T00:00:00.000Z',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z'
+      };
+
+      const dto = toStonesWalletDTO(mockWallet);
+
+      expect(dto.shard).toBe(1000);
+      expect(dto.crystal).toBe(500);
+      expect(dto.relic).toBe(100);
+      expect(dto.dailyRegen).toBe(50);
+      expect(dto.lastRegenAt).toBe('2024-01-01T00:00:00.000Z');
+      expect((dto as any).id).toBeUndefined();
+      expect((dto as any).userId).toBeUndefined();
+      expect((dto as any).castingStones).toBeUndefined();
+    });
+
+    it('should handle wallet with undefined lastRegenAt', () => {
+      const mockWallet: StoneWallet = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        userId: '987fcdeb-51a2-43d7-8f9e-123456789abc',
+        castingStones: 100,
+        inventoryShard: 20,
+        inventoryCrystal: 5,
+        inventoryRelic: 1,
+        dailyRegen: 3,
+        lastRegenAt: '2024-01-01T00:00:00.000Z',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z'
+      };
+
+      const dto = toStonesWalletDTO(mockWallet);
+
+      expect(dto.shard).toBe(20);
+      expect(dto.crystal).toBe(5);
+      expect(dto.relic).toBe(1);
+      expect(dto.dailyRegen).toBe(3);
+      expect(dto.lastRegenAt).toBe('2024-01-01T00:00:00.000Z');
+      expect((dto as any).id).toBeUndefined();
+      expect((dto as any).userId).toBeUndefined();
+      expect((dto as any).castingStones).toBeUndefined();
+    });
+  });
+
+  describe('DTO Type Safety', () => {
+    it('should return properly typed character DTO', () => {
+      const mockCharacter: Character = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        userId: '987fcdeb-51a2-43d7-8f9e-123456789abc',
+        name: 'Test Character',
+        race: 'Human',
+        class: 'Warrior',
+        level: 1,
+        experience: 0,
+        attributes: {
+          strength: 15,
+          dexterity: 12,
+          constitution: 14,
+          intelligence: 10,
+          wisdom: 13,
+          charisma: 11
+        },
+        skills: ['Swordsmanship'],
+        inventory: [],
+        currentHealth: 10,
+        maxHealth: 10,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z'
+      };
+
+      const dto = toCharacterDTO(mockCharacter);
+
+      // TypeScript should infer the correct type
+      expect(typeof dto.id).toBe('string');
+      expect(typeof dto.name).toBe('string');
+      expect(typeof dto.level).toBe('number');
+      expect(typeof dto.experience).toBe('number');
+      expect(typeof dto.attributes).toBe('object');
+      expect(Array.isArray(dto.skills)).toBe(true);
+      expect(Array.isArray(dto.inventory)).toBe(true);
+      expect(typeof dto.currentHealth).toBe('number');
+      expect(typeof dto.maxHealth).toBe('number');
+      expect(typeof dto.createdAt).toBe('string');
+      expect(typeof dto.updatedAt).toBe('string');
+    });
+
+    it('should return properly typed wallet DTO', () => {
+      const mockWallet: StoneWallet = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        userId: '987fcdeb-51a2-43d7-8f9e-123456789abc',
+        castingStones: 150,
+        inventoryShard: 25,
+        inventoryCrystal: 10,
+        inventoryRelic: 2,
+        dailyRegen: 5,
+        lastRegenAt: '2024-01-01T00:00:00.000Z',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z'
+      };
+
+      const dto = toStonesWalletDTO(mockWallet);
+
+      // TypeScript should infer the correct type
+      expect(typeof dto.shard).toBe('number');
+      expect(typeof dto.crystal).toBe('number');
+      expect(typeof dto.relic).toBe('number');
+      expect(typeof dto.dailyRegen).toBe('number');
+      expect(typeof dto.lastRegenAt).toBe('string');
+    });
+  });
+});

--- a/backend/src/utils/dto-mappers.ts
+++ b/backend/src/utils/dto-mappers.ts
@@ -16,7 +16,7 @@ import type {
 } from 'shared';
 import type { Game } from '../services/games.service.js';
 
-// Character DTO mapper
+// Character DTO mapper (redacts internal fields)
 export function toCharacterDTO(character: Character): CharacterDTO {
   return {
     id: character.id,
@@ -30,8 +30,14 @@ export function toCharacterDTO(character: Character): CharacterDTO {
     inventory: character.inventory,
     currentHealth: character.currentHealth,
     maxHealth: character.maxHealth,
+    worldSlug: character.worldSlug,
     createdAt: character.createdAt,
     updatedAt: character.updatedAt,
+    // Explicitly exclude internal fields:
+    // - userId (server-only)
+    // - cookieId (server-only)
+    // - internalFlags (server-only)
+    // - systemMetadata (server-only)
   };
 }
 

--- a/docs/mvp-layerer-plan.md
+++ b/docs/mvp-layerer-plan.md
@@ -1,0 +1,281 @@
+# StoneCaster — Product-Manager Layered Plan (Tester-Ready MVP to RC)
+
+**Purpose:** Deliver a fully testable product from MVP to Release Candidate using focused, hardened layers. Each layer contains **Objectives**, **Scope & Rules**, and **Acceptance Criteria**. No implementation details or static code—only requirements the team can build and QA against.
+
+---
+
+## Core Principles (apply to all layers)
+
+* **Mobile-first UX** with React + Tailwind.
+* **Server-only state**: prompt assembly and full game state never leave the server. Clients receive **UI DTO subsets** only.
+* **Accurate Identity**: Authentication via Supabase JWT; no client-supplied IDs for ownership. Optional cookie identity for guests.
+* **Config in One Place**: All numeric or toggle values come from a single runtime config source (env/DB). No hard-coded magic numbers.
+* **Wrappers Only**: Third-party services (Auth, AI, Payments, Monitoring) are accessed via a single wrapper layer; swappable without refactor.
+* **Stone Ledger**: Every change to stone balances (grant, spend, purchase, restore) writes an immutable ledger entry.
+* **TDD-first**: Tests/specs are written before implementation. Each layer merges only when all acceptance criteria pass.
+* **Security by Design**: DTO redaction, CSRF protection on profile updates, webhook verification, idempotency on spend/turns, minimal data exposure.
+
+---
+
+## Layer M0 — Baseline & Static Content Loader
+
+**Objectives**
+
+* App boots reliably. Testers can fetch the 7 worlds and their adventures/scenarios from **static JSON/TS** embedded in the repo.
+* Basic authentication check surface.
+
+**Scope & Rules**
+
+* `/api/content/worlds` returns UI-safe DTOs derived from static content (no editor-only fields).
+* `/api/me` reflects authentication state.
+* Standard response envelope `{ ok, data?|error?, meta }` with trace identifier on all endpoints.
+
+**Acceptance Criteria**
+
+* Content endpoint returns only fields the UI uses; unknown fields are omitted.
+* `/api/me` returns expected user/null structure.
+* Envelope and traceId appear on all responses.
+
+---
+
+## Layer M1 — Characters & Wallet Foundations
+
+**Objectives**
+
+* Testers can create/manage **Characters** (guest or auth). Characters belong to a **World**.
+* Display a simple **Casting Stones** balance for authenticated users.
+
+**Scope & Rules**
+
+* Characters require a valid `worldSlug` (must match static content).
+* Casting Stones balance readable for authenticated users; no purchases or conversions yet.
+* Ledger exists and will be used when stones change in later layers.
+
+**Acceptance Criteria**
+
+* Character CRUD works with correct ownership (guest/auth) and valid world membership.
+* Invalid `worldSlug` is rejected.
+* Wallet read returns a Casting Stones balance for authenticated users; guests may be out of scope here.
+
+---
+
+## Layer M2 — Game Spawn & Single-Active Constraint
+
+**Objectives**
+
+* Testers can **spawn** a game from an adventure and later **resume**.
+* Enforce: one character can be **active on only one game** at a time.
+* Establish the **guest-first** flow: browsing and first play do **not** require an account.
+
+**Scope & Rules**
+
+* `POST /api/games` with `{ adventureSlug, characterId? }` succeeds for **guest (cookie)** or **authenticated** owners.
+* Adventure must belong to the character’s world; invalid slugs rejected.
+* On first play (if configured), grant starter stones (config-driven) to enable initial turns.
+* **Owner resolution is server-only**: JWT → user owner; else httpOnly cookie → guest owner; never accept IDs from client.
+* Spawning as guest does **not** force account creation.
+* A character may be **active on one game**; spawning another with same character returns conflict.
+
+**Acceptance Criteria**
+
+* Game spawns end-to-end for a guest (cookie) without creating an account; `GET /api/games/:id` returns DTO.
+* Game spawns end-to-end for an authenticated user with identical behavior.
+* Second spawn attempt with active character → conflict error.
+* Starter stones grant (if enabled) appears for the correct owner; no leakage of internal state.
+* No prompts to sign up during spawn; auth prompts appear only at gated actions (see M6/M7).
+
+---
+
+## Layer M3 — Turn Engine (Buffered AI, Spend, Idempotency)
+
+**Objectives**
+
+* Fully playable **turn loop** for both guest and authenticated owners.
+* Ensure the route **never streams**; backend buffers AI JSON, applies state, then returns a single DTO.
+
+**Scope & Rules**
+
+* Turns consume **Casting Stones** at a config-defined cost for **both** guest and authenticated owners; all spends append ledger entries.
+* Turn requests require an **Idempotency-Key** and are atomic.
+* Prompt assembly is **server-only** (string templates for MVP) and version-checked.
+* **No front-end streaming**: a single validated DTO is returned per turn with story blocks, next choices, display-safe relationship/faction changes, and updated stone balance.
+* Guests can take turns while stones remain; **Save/Continue/Purchase/Profile** actions remain **gated** (see M6/M7/M8).
+
+**Acceptance Criteria**
+
+* Guest turn succeeds with correct stone spend and ledger write; authenticated turn behaves identically.
+* Missing or duplicate idempotency key handled correctly (no double-spend; consistent response).
+* Insufficient stones → clear error; no state advancement or ledger spend.
+* Response is **one** complete DTO (no partials/streams) and never exposes internal state or prompt text.
+
+---
+
+## Layer M4 — Play UI (Mobile-First)
+
+**Objectives**
+
+* Deliver a **Unified Player** suitable for playtesting on mobile: story stream, choices with visible cost, stones badge, and adventure header.
+
+**Scope & Rules**
+
+* **No front-end streaming.** The backend receives a **full JSON turn result from AI**, applies server-side state changes (story text, relationship/faction deltas, any flags), and returns a **single DTO response** to the UI.
+* UI renders only the DTO subset: story text blocks, choice list (ids/labels), surfaced relationship/faction changes (display-safe), current stone balance, and lightweight game metadata.
+* UI never builds prompts or infers hidden state; no partial/incremental render per turn.
+* Clear error and retry states for turn failures and network issues.
+
+**Acceptance Criteria**
+
+* On taking a turn, the UI shows a single update based on the **server-processed DTO** (no intermediate/streamed frames).
+* DTO includes: new story blocks, available choices, and any **display-ready relationship/faction changes** (if present), along with updated stone count.
+* No internal fields (full `state_snapshot`, prompt text, internal flags) are exposed to the client.
+* Testers can sign in, select an adventure, spawn a game, and complete multiple turns with responsive feedback on mobile.
+
+---
+
+## Layer M5 — Hardening & QA Readiness
+
+**Objectives**
+
+* Improve reliability and diagnosability for playtests.
+
+**Scope & Rules**
+
+* Add structured logs with traceId for requests and errors.
+* Optional telemetry endpoint (feature-flagged, sampled via config).
+* Provide a simple tester runbook (how to sign in, start, take turns, report issues).
+
+**Acceptance Criteria**
+
+* Logs contain route, status, latency, and error code (if any).
+* Telemetry (if enabled) records events without exposing sensitive data.
+* Documentation is sufficient for testers to onboard themselves.
+
+---
+
+## Layer M6 — Profiles & Account Safety
+
+**Objectives**
+
+* Testers can view/update **Profile** data and manage sessions.
+* Establish the **upgrade path**: convert an active **guest** session into an **authenticated** account **on-demand** (when the user invokes gated actions like Save/Continue/Purchase/Profile).
+
+**Scope & Rules**
+
+* All profile actions require authentication; unauthenticated requests are blocked.
+* **Guest→Auth Linking** occurs immediately after successful sign-in:
+
+  * Current device’s guest-owned games and stone balance are **linked/merged** into the authenticated account internally.
+  * A ledger entry records the merge (e.g., `LINK_MERGE`).
+  * Operation is **idempotent** and never exposes cookie/group IDs to clients.
+* Profile updates are protected from CSRF/misuse via a clear, testable mechanism.
+* DTO redaction applies: no provider IDs, tokens, or internal flags.
+* Optional: ability to **revoke other sessions** for the account.
+
+**Acceptance Criteria**
+
+* From an active guest game, signing in returns the tester to the same game; ownership is now the authenticated user.
+* Guest stones and games appear under the user after linking; ledger includes a single `LINK_MERGE` entry; repeating the link produces no duplicates.
+* Profile read/update works with strict validation and CSRF protection; unauthenticated requests are blocked.
+* Attempting a gated action while guest (e.g., list my games, save slot, purchase) returns a clear `REQUIRES_AUTH` error; after sign-in, the same action succeeds without data loss.
+
+---
+
+## Layer M7 — Save Games Management (Cloud Saves)
+
+**Objectives**
+
+* Reliable **save and resume** with automatic checkpoints and manual save slots.
+* Reinforce the **auth gate**: Save/Continue requires authentication, but an **active guest** can upgrade mid-session without losing progress.
+
+**Scope & Rules**
+
+* Every successful turn writes an automatic checkpoint server-side (no client exposure of raw snapshots).
+* **Manual save slots** can be created, listed, and restored **by authenticated owners only**.
+* Guests attempting Save/Continue are prompted to authenticate; upon success, their **current guest game** is linked to the account and the save operation proceeds.
+* Restores are auditable and append to the ledger (e.g., `RESTORE`) if stones/state implications apply; history is not erased.
+* Client sees only slot metadata (labels/timestamps), never full snapshots.
+
+**Acceptance Criteria**
+
+* As guest: playing and then tapping **Save/Continue** yields `REQUIRES_AUTH`; after sign-in, the same action succeeds and the existing guest game is preserved under the user.
+* Manual save slot creation, listing, and restore work for authenticated users only; unauthorized attempts are blocked.
+* Restoring a slot deterministically returns the game to the saved state; subsequent turns continue from there.
+* No internal snapshots or hidden state are exposed to clients at any point.
+
+---
+
+## Layer M8 — Payments & Stone Purchases (Test-Mode)
+
+**Objectives**
+
+* Allow testers to **purchase stones in test mode** to continue play without manual grants.
+
+**Scope & Rules**
+
+* List purchasable packs from config; create a checkout session through a **payments wrapper** (e.g., Stripe behind abstraction).
+* Process webhooks securely (signature verification in wrapper) and credit stones accordingly.
+* All mutations append ledger entries (e.g., `PURCHASE`).
+* Client responses never expose provider-specific IDs or secrets.
+
+**Acceptance Criteria**
+
+* Testers can complete a test-mode purchase and see their stone balance increase.
+* Invalid signatures are rejected; no credit applied.
+* Ledger reflects accurate deltas and reasons.
+
+---
+
+## Layer M9 — Prompt System Hardening & Safety
+
+**Objectives**
+
+* Make prompt building robust, auditable, and safe for accounts and IP.
+
+**Scope & Rules**
+
+* **Allowlisted variables** only in templates (world/adventure/scenario metadata, server summary, character traits, last choice).
+* Enforce **schema version** compatibility (template must match current app schema version).
+* Maintain a **prompt audit log** (template id/version/hash used per turn) without storing raw prompt text in client-facing responses.
+* Add a **PII guard** to remove profile identifiers (e.g., emails, usernames) from prompt context.
+* Strengthen AI JSON validation with an optional repair/strict mode and failure metrics.
+
+**Acceptance Criteria**
+
+* Templates referencing out-of-scope variables are rejected before use.
+* Mismatched schema versions are denied; matching versions proceed.
+* Audit log entries exist for each turn, with verifiable template hashes.
+* No personal identifiers appear in prompt context.
+
+---
+
+## Layer M10 — Release Candidate QA Suite
+
+**Objectives**
+
+* Validate the product for wider testing: performance, security, and reliability.
+
+**Scope & Rules**
+
+* Load tests for key flows: sign in → spawn → 3 turns → save.
+* Security checks: authZ correctness, CSRF effectiveness for profile, webhook verification for payments.
+* Regression suite for characters, games, turns, saves, purchases.
+* Resilience tests: AI failure handling, DB restart behavior, idempotency under retries.
+
+**Acceptance Criteria**
+
+* Performance meets acceptable thresholds (document p95 latency targets).
+* No data leakage across accounts; all ownership checks pass.
+* End-to-end scenarios are green; recovery from transient failures is correct.
+
+---
+
+## Global Acceptance for Tester-Ready Release
+
+* **End-to-end gameplay is reliable**: sign in → create character → spawn → take turns → save → resume → optional test purchase.
+* **Account safety** and identity accuracy are ensured (no cross-account access, CSRF protections, revocable sessions).
+* **Purchases** credit stones in test mode and are auditable via the ledger.
+* **Prompts** are assembled server-side with strict validation and no leakage.
+* **DTO redaction** is enforced on all endpoints.
+* **Documentation** gives testers clear instructions to play and report issues.
+
+> After RC, move static content to DB in phases, add feature-flag controls to enable richer worlds, and consider WebSockets for push updates once stability is proven.

--- a/shared/src/types/api.ts
+++ b/shared/src/types/api.ts
@@ -86,6 +86,7 @@ export const CreateCharacterRequestSchema = z.object({
   })).default([]),
   currentHealth: z.number().int().min(0).optional(),
   maxHealth: z.number().int().min(1).optional(),
+  worldSlug: z.string().min(1).max(100), // Required world validation
 });
 
 export const UpdateCharacterRequestSchema = CreateCharacterRequestSchema.partial();

--- a/shared/src/types/dto.ts
+++ b/shared/src/types/dto.ts
@@ -25,6 +25,7 @@ export const CharacterDTOSchema = z.object({
   })),
   currentHealth: z.number().int(),
   maxHealth: z.number().int(),
+  worldSlug: z.string(), // Include world slug in DTO
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 });

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 // Character Schema
 export const CharacterSchema = z.object({
   id: z.string().uuid(),
-  userId: z.string().uuid(),
+  userId: z.string().uuid().optional(), // Optional for guest users
+  cookieId: z.string().uuid().optional(), // Optional for authenticated users
   name: z.string().min(1).max(50),
   race: z.string(),
   class: z.string(),
@@ -26,6 +27,7 @@ export const CharacterSchema = z.object({
   })),
   currentHealth: z.number().int().min(0),
   maxHealth: z.number().int().min(1),
+  worldSlug: z.string().min(1).max(100), // Required world validation
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 });

--- a/supabase/migrations/009_m1_characters_wallet.sql
+++ b/supabase/migrations/009_m1_characters_wallet.sql
@@ -1,0 +1,224 @@
+-- Layer M1 - Characters & Wallet Foundations Migration
+-- Adds world validation, guest support, and wallet access controls
+
+-- Add world_slug column to characters table
+ALTER TABLE characters ADD COLUMN IF NOT EXISTS world_slug VARCHAR(100);
+
+-- Add cookie_id column to characters table for guest support
+ALTER TABLE characters ADD COLUMN IF NOT EXISTS cookie_id UUID;
+
+-- Add constraint to ensure either user_id or cookie_id is present (but not both)
+ALTER TABLE characters ADD CONSTRAINT characters_owner_check 
+  CHECK (
+    (user_id IS NOT NULL AND cookie_id IS NULL) OR 
+    (user_id IS NULL AND cookie_id IS NOT NULL)
+  );
+
+-- Create index for world_slug lookups
+CREATE INDEX IF NOT EXISTS idx_characters_world_slug ON characters(world_slug);
+
+-- Create index for cookie_id lookups
+CREATE INDEX IF NOT EXISTS idx_characters_cookie_id ON characters(cookie_id);
+
+-- Update RLS policies to support both authenticated users and guests
+DROP POLICY IF EXISTS "Users can view their own characters" ON characters;
+DROP POLICY IF EXISTS "Users can insert their own characters" ON characters;
+DROP POLICY IF EXISTS "Users can update their own characters" ON characters;
+DROP POLICY IF EXISTS "Users can delete their own characters" ON characters;
+
+-- New RLS policies that support both authenticated users and guests
+CREATE POLICY "Users can view their own characters"
+  ON characters FOR SELECT
+  USING (
+    (auth.uid() IS NOT NULL AND user_id = auth.uid()) OR
+    (auth.uid() IS NULL AND cookie_id IS NOT NULL)
+  );
+
+CREATE POLICY "Users can insert their own characters"
+  ON characters FOR INSERT
+  WITH CHECK (
+    (auth.uid() IS NOT NULL AND user_id = auth.uid()) OR
+    (auth.uid() IS NULL AND cookie_id IS NOT NULL)
+  );
+
+CREATE POLICY "Users can update their own characters"
+  ON characters FOR UPDATE
+  USING (
+    (auth.uid() IS NOT NULL AND user_id = auth.uid()) OR
+    (auth.uid() IS NULL AND cookie_id IS NOT NULL)
+  );
+
+CREATE POLICY "Users can delete their own characters"
+  ON characters FOR DELETE
+  USING (
+    (auth.uid() IS NOT NULL AND user_id = auth.uid()) OR
+    (auth.uid() IS NULL AND cookie_id IS NOT NULL)
+  );
+
+-- Add service role policies for server-side operations
+CREATE POLICY "Service role can manage all characters"
+  ON characters FOR ALL
+  TO service_role
+  USING (TRUE);
+
+-- Update stone_wallets table to support guest users
+-- Add cookie_group_id column for guest wallets
+ALTER TABLE stone_wallets ADD COLUMN IF NOT EXISTS cookie_group_id UUID REFERENCES cookie_groups(id) ON DELETE CASCADE;
+
+-- Update constraint to ensure either user_id or cookie_group_id is present (but not both)
+ALTER TABLE stone_wallets DROP CONSTRAINT IF EXISTS stone_wallets_user_id_key;
+ALTER TABLE stone_wallets ADD CONSTRAINT stone_wallets_owner_check 
+  CHECK (
+    (user_id IS NOT NULL AND cookie_group_id IS NULL) OR 
+    (user_id IS NULL AND cookie_group_id IS NOT NULL)
+  );
+
+-- Create index for cookie_group_id lookups
+CREATE INDEX IF NOT EXISTS idx_stone_wallets_cookie_group_id ON stone_wallets(cookie_group_id);
+
+-- Update RLS policies for stone_wallets to support guests
+DROP POLICY IF EXISTS "Users can view their own wallet" ON stone_wallets;
+DROP POLICY IF EXISTS "Users can update their own wallet" ON stone_wallets;
+DROP POLICY IF EXISTS "System can insert wallets for users" ON stone_wallets;
+
+-- New RLS policies that support both authenticated users and guests
+CREATE POLICY "Users can view their own wallet"
+  ON stone_wallets FOR SELECT
+  USING (
+    (auth.uid() IS NOT NULL AND user_id = auth.uid()) OR
+    (auth.uid() IS NULL AND cookie_group_id IS NOT NULL)
+  );
+
+CREATE POLICY "Users can update their own wallet"
+  ON stone_wallets FOR UPDATE
+  USING (
+    (auth.uid() IS NOT NULL AND user_id = auth.uid()) OR
+    (auth.uid() IS NULL AND cookie_group_id IS NOT NULL)
+  );
+
+CREATE POLICY "System can insert wallets for users and guests"
+  ON stone_wallets FOR INSERT
+  WITH CHECK (
+    (auth.uid() IS NOT NULL AND user_id = auth.uid()) OR
+    (auth.uid() IS NULL AND cookie_group_id IS NOT NULL)
+  );
+
+-- Add service role policies for server-side operations
+CREATE POLICY "Service role can manage all wallets"
+  ON stone_wallets FOR ALL
+  TO service_role
+  USING (TRUE);
+
+-- Update stone_ledger table to support guest users
+-- Add cookie_group_id column for guest ledger entries
+ALTER TABLE stone_ledger ADD COLUMN IF NOT EXISTS cookie_group_id UUID REFERENCES cookie_groups(id) ON DELETE CASCADE;
+
+-- Update constraint to ensure either user_id or cookie_group_id is present (but not both)
+ALTER TABLE stone_ledger ADD CONSTRAINT stone_ledger_owner_check 
+  CHECK (
+    (user_id IS NOT NULL AND cookie_group_id IS NULL) OR 
+    (user_id IS NULL AND cookie_group_id IS NOT NULL)
+  );
+
+-- Create index for cookie_group_id lookups
+CREATE INDEX IF NOT EXISTS idx_stone_ledger_cookie_group_id ON stone_ledger(cookie_group_id);
+
+-- Update RLS policies for stone_ledger to support guests
+DROP POLICY IF EXISTS "Users can view their own ledger entries" ON stone_ledger;
+DROP POLICY IF EXISTS "System can insert ledger entries" ON stone_ledger;
+
+-- New RLS policies that support both authenticated users and guests
+CREATE POLICY "Users can view their own ledger entries"
+  ON stone_ledger FOR SELECT
+  USING (
+    (auth.uid() IS NOT NULL AND user_id = auth.uid()) OR
+    (auth.uid() IS NULL AND cookie_group_id IS NOT NULL)
+  );
+
+CREATE POLICY "System can insert ledger entries for users and guests"
+  ON stone_ledger FOR INSERT
+  WITH CHECK (
+    (auth.uid() IS NOT NULL AND user_id = auth.uid()) OR
+    (auth.uid() IS NULL AND cookie_group_id IS NOT NULL)
+  );
+
+-- Add service role policies for server-side operations
+CREATE POLICY "Service role can manage all ledger entries"
+  ON stone_ledger FOR ALL
+  TO service_role
+  USING (TRUE);
+
+-- Create function to get or create guest wallet
+CREATE OR REPLACE FUNCTION get_or_create_guest_wallet(p_cookie_group_id UUID)
+RETURNS UUID AS $$
+DECLARE
+  v_wallet_id UUID;
+BEGIN
+  -- Try to get existing wallet
+  SELECT id INTO v_wallet_id
+  FROM stone_wallets
+  WHERE cookie_group_id = p_cookie_group_id;
+  
+  -- Create new wallet if it doesn't exist
+  IF v_wallet_id IS NULL THEN
+    INSERT INTO stone_wallets (cookie_group_id, casting_stones, inventory_shard, inventory_crystal, inventory_relic, daily_regen, last_regen_at)
+    VALUES (p_cookie_group_id, 0, 0, 0, 0, 0, NOW())
+    RETURNING id INTO v_wallet_id;
+  END IF;
+  
+  RETURN v_wallet_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create function to validate world slug
+CREATE OR REPLACE FUNCTION validate_world_slug(p_world_slug TEXT)
+RETURNS BOOLEAN AS $$
+BEGIN
+  -- Check if world slug is in the allowed list
+  -- This matches the worlds from the static content
+  RETURN p_world_slug IN (
+    'mystika',
+    'aetherium', 
+    'voidreach',
+    'whispercross',
+    'paragon-city',
+    'veloria',
+    'noctis-veil'
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+-- Add trigger to validate world_slug on character creation/update
+CREATE OR REPLACE FUNCTION validate_character_world_slug()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Validate world_slug if provided
+  IF NEW.world_slug IS NOT NULL AND NOT validate_world_slug(NEW.world_slug) THEN
+    RAISE EXCEPTION 'Invalid world slug: %', NEW.world_slug;
+  END IF;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger for world_slug validation
+DROP TRIGGER IF EXISTS trigger_validate_character_world_slug ON characters;
+CREATE TRIGGER trigger_validate_character_world_slug
+  BEFORE INSERT OR UPDATE ON characters
+  FOR EACH ROW
+  EXECUTE FUNCTION validate_character_world_slug();
+
+-- Add comments for documentation
+COMMENT ON COLUMN characters.world_slug IS 'World identifier from static content (e.g., mystika, aetherium)';
+COMMENT ON COLUMN characters.cookie_id IS 'Guest cookie ID for guest users (mutually exclusive with user_id)';
+COMMENT ON COLUMN stone_wallets.cookie_group_id IS 'Guest cookie group ID for guest wallets (mutually exclusive with user_id)';
+COMMENT ON COLUMN stone_ledger.cookie_group_id IS 'Guest cookie group ID for guest ledger entries (mutually exclusive with user_id)';
+
+-- Add function to migrate existing characters to have world_slug
+-- This sets a default world_slug for existing characters
+UPDATE characters 
+SET world_slug = 'mystika' 
+WHERE world_slug IS NULL;
+
+-- Make world_slug NOT NULL after setting defaults
+ALTER TABLE characters ALTER COLUMN world_slug SET NOT NULL;


### PR DESCRIPTION
Introduces service layers for character CRUD and world validation, refactors character and stones routes to use these services, and adds comprehensive M1 tests for character and wallet endpoints. Also adds static content service for world/adventure data, updates DTO mappers and shared types, and documents the MVP layerer plan. Includes new Supabase migration for character wallet support.